### PR TITLE
056: add GitHub Pages — landing + docs

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>zvault — Documentation</title>
+  <meta name="description" content="Planned CLI commands and usage for zvault.">
+  <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+
+    <nav class="nav">
+      <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+      <a href="index.html">zvault</a>
+      <a href="https://github.com/zarlcorp/zvault">GitHub</a>
+    </nav>
+
+    <div class="doc-content">
+
+      <h1>zvault docs</h1>
+
+      <blockquote>These commands are planned &mdash; zvault is not yet released. This page documents the intended CLI interface.</blockquote>
+
+      <h2>Interactive mode</h2>
+      <p>Launch the TUI for browsing and managing secrets:</p>
+      <pre><code>$ zvault</code></pre>
+      <p>You'll be prompted for your master password, then presented with an interactive interface for navigating entries, searching, and copying secrets to the clipboard.</p>
+
+      <h2>CLI commands</h2>
+
+      <h3>Retrieve a secret</h3>
+      <pre><code>$ zvault get &lt;path&gt;</code></pre>
+      <p>Prints the value of the entry at <code>&lt;path&gt;</code> to stdout. Useful for scripting and piping into other commands.</p>
+
+      <h3>Store a secret</h3>
+      <pre><code>$ zvault set &lt;path&gt;</code></pre>
+      <p>Prompts for the secret value and stores it encrypted at the given path. If the path already exists, the entry is overwritten.</p>
+
+      <h3>Search entries</h3>
+      <pre><code>$ zvault search &lt;query&gt;</code></pre>
+      <p>Searches entry names, tags, and folder paths. Returns matching entries without revealing secret values.</p>
+
+      <hr>
+
+      <p><a href="index.html">&larr; Back to zvault</a></p>
+
+    </div>
+
+    <footer class="footer">
+      <p>Open source. MIT licensed.</p>
+      <p><a href="https://github.com/zarlcorp/zvault">github.com/zarlcorp/zvault</a></p>
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>zvault — Encrypted local storage for secrets.</title>
+  <meta name="description" content="Encrypted local storage for secrets, keys, notes. Your data, your machine, your keys.">
+  <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+
+    <nav class="nav">
+      <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+      <a href="docs.html">Docs</a>
+      <a href="https://github.com/zarlcorp/zvault">GitHub</a>
+    </nav>
+
+    <header class="hero">
+      <div class="logo">zvault</div>
+      <div class="tagline">Encrypted local storage for secrets, keys, notes. Your data, your machine, your keys.</div>
+      <div class="status-badge">Coming soon</div>
+    </header>
+
+    <section class="features">
+      <ul class="feature-list">
+        <li>Store secrets encrypted at rest</li>
+        <li>Master password with Argon2id key derivation</li>
+        <li>Organize with tags and folders</li>
+        <li>Search across entries</li>
+        <li>Auto-lock after inactivity</li>
+        <li>Export/import (encrypted format only)</li>
+      </ul>
+    </section>
+
+    <footer class="footer">
+      <p>Open source. MIT licensed.</p>
+      <p><a href="https://github.com/zarlcorp/zvault">github.com/zarlcorp/zvault</a></p>
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,45 @@
+/* zvault page-specific overrides */
+/* shared design system lives at https://zarlcorp.github.io/shared.css */
+
+/* single-viewport landing — tighten hero spacing */
+
+.hero {
+  padding: 3rem 0 1.5rem;
+}
+
+.tagline {
+  font-size: 1rem;
+  color: var(--muted);
+  font-weight: 400;
+  max-width: 520px;
+  margin: 0.5rem auto 0;
+}
+
+/* coming soon badge below tagline */
+
+.status-badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--muted);
+  border: 1px solid var(--subtle);
+  border-radius: 4px;
+  padding: 0.25rem 0.75rem;
+  margin-top: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* features section — centered, compact */
+
+.features {
+  padding: 1.5rem 0 2rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+/* footer — tighter for single viewport */
+
+.footer {
+  padding: 2rem 0 3rem;
+}


### PR DESCRIPTION
Closes #4

Adds docs/index.html (single-viewport landing page with Coming Soon status) and docs/docs.html (planned CLI documentation). Uses shared CSS design system from zarlcorp.github.io.

Spec: zarlcorp/core/.manager/specs/056-zvault-pages.md