### PR TITLE
add GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ make lint
 
 ## Learn More
 
+- [Website](https://zarlcorp.github.io/zvault) — Documentation and install instructions
 - [zarlcorp/core](https://github.com/zarlcorp/core) — Shared packages for zarlcorp tools
 - [MANIFESTO.md](https://github.com/zarlcorp/core/blob/main/MANIFESTO.md) — Why we exist and what we're building
 


### PR DESCRIPTION
Adds a link to https://zarlcorp.github.io/zvault in the Learn More section.