### PR TITLE
068: fix nav bar consistency

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -9,15 +9,13 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="bar">
+  <nav class="bar">
     <div class="container">
-      <nav class="nav">
-        <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
-        <a href="index.html">Home</a>
-        <a href="https://github.com/zarlcorp/zvault">GitHub</a>
-      </nav>
+      <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+      <a href="index.html">zvault</a>
+      <a href="https://github.com/zarlcorp/zvault">github</a>
     </div>
-  </div>
+  </nav>
 
   <div class="container">
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,16 +9,13 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="bar">
+  <nav class="bar">
     <div class="container">
-      <nav class="nav">
-        <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
-        <a href="docs.html">Docs</a>
-        <a href="https://zarlcorp.github.io">Org</a>
-        <a href="https://github.com/zarlcorp/zvault">GitHub</a>
-      </nav>
+      <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+      <a href="docs.html">documentation</a>
+      <a href="https://github.com/zarlcorp/zvault">github</a>
     </div>
-  </div>
+  </nav>
 
   <div class="landing">
     <div class="container">


### PR DESCRIPTION
Nav bar on landing and docs pages now matches org site pattern: zarlcorp | documentation | github (all lowercase). Fixed HTML structure and removed extra Org link.