### PR TITLE
075: lowercase all website copy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>zvault — Encrypted local storage for secrets.</title>
-  <meta name="description" content="Encrypted local storage for secrets, keys, notes. Your data, your machine, your keys.">
+  <title>zvault — encrypted local storage for secrets.</title>
+  <meta name="description" content="encrypted local storage for secrets, keys, notes. your data, your machine, your keys.">
   <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -22,8 +22,8 @@
 
       <header class="hero">
         <div class="logo">zvault</div>
-        <div class="tagline">Encrypted local storage for secrets, keys, notes. Your data, your machine, your keys.</div>
-        <div class="status-badge">Coming soon</div>
+        <div class="tagline">encrypted local storage for secrets, keys, notes. your data, your machine, your keys.</div>
+        <div class="status-badge">coming soon</div>
       </header>
 
       <section class="features">
@@ -31,18 +31,18 @@
           <div class="window-title">planned features</div>
           <div class="window-content">
             <ul class="feature-list">
-              <li>Encrypted local vault with age encryption</li>
-              <li>Key management and secret storage</li>
-              <li>Secure notes with full-text search</li>
-              <li>Interactive TUI + scriptable CLI</li>
-              <li>Single binary, no cloud, no accounts</li>
+              <li>encrypted local vault with age encryption</li>
+              <li>key management and secret storage</li>
+              <li>secure notes with full-text search</li>
+              <li>interactive TUI + scriptable CLI</li>
+              <li>single binary, no cloud, no accounts</li>
             </ul>
           </div>
         </div>
       </section>
 
       <footer class="footer">
-        <p>Open source. MIT licensed.</p>
+        <p>open source. MIT licensed.</p>
         <p><a href="https://zarlcorp.github.io">zarlcorp.github.io</a></p>
       </footer>
 


### PR DESCRIPTION
Closes #11

Spec: zarlcorp/core/.manager/specs/075-lowercase-all-copy.md

Lowercased all text in docs/index.html. Technical acronyms and brand names preserved.