### PR TITLE
050: add release workflow, update docs and readme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,9 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+jobs:
+  release:
+    uses: zarlcorp/.github/.github/workflows/go-release.yml@main
+    secrets:
+      TAP_TOKEN: ${{ secrets.TAP_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: build test lint run clean
 
+VERSION ?= dev
+
 build:
-	go build -o bin/zvault ./cmd/zvault
+	go build -ldflags "-X main.version=$(VERSION)" -o bin/zvault ./cmd/zvault
 
 test:
 	go test -race ./...

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Encrypted local storage for secrets, keys, notes.
 
-Manage your sensitive data with a simple terminal interface. zvault stores everything encrypted on your machine — your data, your device, your keys. No sync, no cloud, no servers. Download the binary and run.
+Manage your sensitive data with a simple terminal interface. zvault stores everything encrypted on your machine -- your data, your device, your keys. No sync, no cloud, no servers. Download the binary and run.
 
 ## Install
 
@@ -26,53 +26,117 @@ brew install zarlcorp/tap/zvault
 go install github.com/zarlcorp/zvault/cmd/zvault@latest
 ```
 
-## Usage
+## Quickstart
 
-Start the interactive terminal interface:
+Launch the interactive TUI:
 
 ```bash
 zvault
 ```
 
-View version information:
+Or use the CLI directly:
+
+```bash
+# store a password
+zvault secret store -t password -n github
+
+# add a high-priority task
+zvault task add -p h -d tomorrow "deploy to prod"
+
+# list your secrets
+zvault secret list
+
+# search for a secret
+zvault secret search github
+
+# check version
+zvault version
+```
+
+## Commands
+
+### Secrets
+
+```bash
+zvault secret store -t <type> -n <name> [--tags tag1,tag2]
+zvault secret get <id-or-name> [--show]
+zvault secret list [-t <type>] [--tag <tag>]
+zvault secret delete <id-or-name>
+zvault secret search <query>
+```
+
+Secret types: `password`, `apikey`, `sshkey`, `note`.
+
+Use `--show` with `get` to reveal sensitive values (masked by default).
+
+### Tasks
+
+```bash
+zvault task add [-p <h|m|l>] [-d <date>] [--tags tag1,tag2] <title>
+zvault task list [--pending] [--done] [-p <h|m|l>] [--tag <tag>]
+zvault task done <id>
+zvault task edit <id> <new title>
+zvault task rm <id>
+zvault task clear
+```
+
+Due date formats: `YYYY-MM-DD`, `today`, `tomorrow`, `next week`, `+3d`.
+
+### Export
+
+```bash
+zvault export [--tasks] [--secrets] [--pending] [--done]
+```
+
+Exports vault data as markdown. Without flags, exports everything.
+
+### Shell Completions
+
+```bash
+# bash
+eval "$(zvault completion bash)"
+
+# zsh
+eval "$(zvault completion zsh)"
+
+# fish
+zvault completion fish | source
+```
+
+### Version
 
 ```bash
 zvault version
 ```
 
-Planned CLI subcommands (not yet implemented):
+## Configuration
 
-```bash
-zvault get <path>          # retrieve a secret
-zvault set <path>          # store a secret
-zvault search <query>      # find secrets by name
-```
+zvault stores its encrypted vault in `~/.local/share/zvault/`. The vault is initialized on first use via the TUI.
+
+Set `ZVAULT_PASSWORD` to skip interactive password prompts (useful for scripting).
+
+Set `NO_COLOR` to disable colored output.
 
 ## Development
 
-Build the binary:
-
 ```bash
-make build
+make build    # build binary to bin/zvault
+make test     # run tests with race detector
+make lint     # run golangci-lint
+make clean    # remove build artifacts
 ```
 
-Run tests:
+Build with a specific version:
 
 ```bash
-make test
-```
-
-Run linter:
-
-```bash
-make lint
+make build VERSION=1.0.0
 ```
 
 ## Learn More
 
-- [zarlcorp.github.io/zvault](https://zarlcorp.github.io/zvault) — documentation and install instructions
-- [zarlcorp/core](https://github.com/zarlcorp/core) — shared packages for zarlcorp tools
-- [MANIFESTO.md](https://github.com/zarlcorp/core/blob/main/MANIFESTO.md) — why we exist and what we're building
+- [zarlcorp.github.io/zvault](https://zarlcorp.github.io/zvault) -- documentation and install instructions
+- [zarlcorp/core](https://github.com/zarlcorp/core) -- shared packages for zarlcorp tools
+- [MANIFESTO.md](https://github.com/zarlcorp/core/blob/main/MANIFESTO.md) -- why we exist and what we're building
 
 ---
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>zvault — Documentation</title>
-  <meta name="description" content="Planned CLI commands and usage for zvault.">
+  <meta name="description" content="CLI command reference for zvault.">
   <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -23,61 +23,183 @@
       <div class="window-title">zvault docs</div>
       <div class="window-content">
         <div class="doc-content">
-          <blockquote>These commands are planned &mdash; zvault is not yet released. This page documents the intended CLI interface.</blockquote>
+          <p>zvault provides an interactive TUI and a scriptable CLI. Run <code>zvault</code> with no arguments to launch the TUI, or use subcommands for automation.</p>
+          <pre><code>zvault &lt;command&gt; [args]
+
+Commands:
+  secret      manage secrets
+  task        manage tasks
+  export      export vault data
+  completion  generate shell completions
+  version     print version
+  help        show help</code></pre>
         </div>
       </div>
     </div>
 
     <div class="window">
-      <div class="window-title">zvault init</div>
+      <div class="window-title">zvault secret store</div>
       <div class="window-content">
         <div class="doc-content">
-          <p>Initialize a new encrypted vault. Creates the vault directory and sets your master password.</p>
-          <pre><code>$ zvault init</code></pre>
-          <p>You'll be prompted to create a master password. The password is used with Argon2id to derive your encryption key. The vault stores all data locally in <code>~/.local/share/zvault/</code>.</p>
+          <p>Create a new secret. You will be prompted for the secret value interactively.</p>
+          <pre><code>zvault secret store -t &lt;type&gt; -n &lt;name&gt; [--tags tag1,tag2]</code></pre>
+          <p>Supported types: <code>password</code>, <code>apikey</code>, <code>sshkey</code>, <code>note</code>.</p>
+          <p>For notes, you can pipe content via stdin:</p>
+          <pre><code>echo "my note" | zvault secret store -t note -n mynote</code></pre>
         </div>
       </div>
     </div>
 
     <div class="window">
-      <div class="window-title">zvault store</div>
+      <div class="window-title">zvault secret get</div>
       <div class="window-content">
         <div class="doc-content">
-          <p>Store a new secret in the vault. Prompts for the secret value and encrypts it with age encryption.</p>
-          <pre><code>$ zvault store &lt;name&gt;</code></pre>
-          <p>The name is the key used to retrieve the secret later. If a secret with that name already exists, it will be overwritten.</p>
+          <p>Retrieve a secret by ID, name, or ID prefix. Sensitive values are masked by default.</p>
+          <pre><code>zvault secret get &lt;id-or-name&gt; [--show]</code></pre>
+          <p>Use <code>--show</code> to reveal sensitive values like passwords and API keys.</p>
         </div>
       </div>
     </div>
 
     <div class="window">
-      <div class="window-title">zvault get</div>
+      <div class="window-title">zvault secret list</div>
       <div class="window-content">
         <div class="doc-content">
-          <p>Retrieve a secret from the vault. Prints the decrypted value to stdout.</p>
-          <pre><code>$ zvault get &lt;name&gt;</code></pre>
-          <p>Useful for scripting and piping into other commands. Requires master password authentication.</p>
+          <p>List all stored secrets. Optionally filter by type or tag.</p>
+          <pre><code>zvault secret list [-t &lt;type&gt;] [--tag &lt;tag&gt;]</code></pre>
         </div>
       </div>
     </div>
 
     <div class="window">
-      <div class="window-title">zvault list</div>
+      <div class="window-title">zvault secret delete</div>
       <div class="window-content">
         <div class="doc-content">
-          <p>List all stored secrets. Shows names without revealing values.</p>
-          <pre><code>$ zvault list</code></pre>
+          <p>Delete a secret. Prompts for confirmation before deleting.</p>
+          <pre><code>zvault secret delete &lt;id-or-name&gt;</code></pre>
         </div>
       </div>
     </div>
 
     <div class="window">
-      <div class="window-title">zvault delete</div>
+      <div class="window-title">zvault secret search</div>
       <div class="window-content">
         <div class="doc-content">
-          <p>Permanently remove a secret from the vault.</p>
-          <pre><code>$ zvault delete &lt;name&gt;</code></pre>
-          <p>This action is irreversible. The encrypted data is securely erased from disk.</p>
+          <p>Search secrets by name.</p>
+          <pre><code>zvault secret search &lt;query&gt;</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault task add</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Add a new task with optional priority, due date, and tags.</p>
+          <pre><code>zvault task add [-p &lt;h|m|l&gt;] [-d &lt;date&gt;] [--tags tag1,tag2] &lt;title&gt;</code></pre>
+          <p>Due date formats: <code>YYYY-MM-DD</code>, <code>today</code>, <code>tomorrow</code>, <code>next week</code>, <code>+3d</code>.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault task list</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>List tasks. Filter by status, priority, or tag.</p>
+          <pre><code>zvault task list [--pending] [--done] [-p &lt;h|m|l&gt;] [--tag &lt;tag&gt;]</code></pre>
+          <p>Alias: <code>zvault task ls</code></p>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault task done</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Mark one or more tasks as complete.</p>
+          <pre><code>zvault task done &lt;id&gt;
+zvault task done &lt;id1&gt;,&lt;id2&gt;</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault task edit</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Rename a task.</p>
+          <pre><code>zvault task edit &lt;id&gt; &lt;new title&gt;</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault task rm</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Delete one or more tasks.</p>
+          <pre><code>zvault task rm &lt;id&gt;
+zvault task rm &lt;id1&gt;,&lt;id2&gt;</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault task clear</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Delete all completed tasks.</p>
+          <pre><code>zvault task clear</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault export</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Export vault data as markdown. By default exports both secrets and tasks.</p>
+          <pre><code>zvault export [--tasks] [--secrets] [--pending] [--done]</code></pre>
+          <p>Use <code>--tasks</code> or <code>--secrets</code> to export only one category. Use <code>--pending</code> or <code>--done</code> to filter tasks by status.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault completion</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Generate shell completion scripts.</p>
+          <pre><code># bash (add to ~/.bashrc)
+eval "$(zvault completion bash)"
+
+# zsh (add to ~/.zshrc)
+eval "$(zvault completion zsh)"
+
+# fish (add to ~/.config/fish/config.fish)
+zvault completion fish | source</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">zvault version</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>Print the zvault version.</p>
+          <pre><code>zvault version</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="window">
+      <div class="window-title">configuration</div>
+      <div class="window-content">
+        <div class="doc-content">
+          <p>zvault stores its encrypted vault in <code>~/.local/share/zvault/</code>. The vault is initialized on first use via the TUI.</p>
+          <p>Set the <code>ZVAULT_PASSWORD</code> environment variable to skip interactive password prompts (useful for scripting).</p>
+          <p>Set <code>NO_COLOR</code> to disable colored output.</p>
         </div>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,20 +23,60 @@
       <header class="hero">
         <div class="logo">zvault</div>
         <div class="tagline">encrypted local storage for secrets, keys, notes. your data, your machine, your keys.</div>
-        <div class="status-badge">coming soon</div>
       </header>
 
       <section class="features">
         <div class="window">
-          <div class="window-title">planned features</div>
+          <div class="window-title">features</div>
           <div class="window-content">
             <ul class="feature-list">
               <li>encrypted local vault with age encryption</li>
               <li>key management and secret storage</li>
               <li>secure notes with full-text search</li>
               <li>interactive TUI + scriptable CLI</li>
+              <li>task tracking with priorities and due dates</li>
+              <li>export to markdown, JSON, CSV</li>
               <li>single binary, no cloud, no accounts</li>
             </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="window">
+          <div class="window-title">install</div>
+          <div class="window-content">
+            <div class="doc-content">
+              <p>via homebrew:</p>
+              <pre><code>brew install zarlcorp/tap/zvault</code></pre>
+              <p>via go:</p>
+              <pre><code>go install github.com/zarlcorp/zvault/cmd/zvault@latest</code></pre>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="features">
+        <div class="window">
+          <div class="window-title">quickstart</div>
+          <div class="window-content">
+            <div class="doc-content">
+              <p>launch the interactive TUI:</p>
+              <pre><code>zvault</code></pre>
+              <p>or use the CLI directly:</p>
+              <pre><code># store a password
+zvault secret store -t password -n github
+
+# add a task
+zvault task add -p h -d tomorrow "deploy to prod"
+
+# list secrets
+zvault secret list
+
+# search
+zvault secret search github</code></pre>
+              <p>see the <a href="docs.html">full documentation</a> for all commands.</p>
+            </div>
           </div>
         </div>
       </section>

--- a/docs/style.css
+++ b/docs/style.css
@@ -4,21 +4,6 @@
 /* tool accent — mauve */
 :root { --accent: var(--mauve); }
 
-/* coming soon indicator */
-
-.status-badge {
-  display: inline-block;
-  font-size: 0.7rem;
-  color: var(--overlay1);
-  border: 1px solid var(--surface1);
-  border-radius: 4px;
-  padding: 0.2rem 0.65rem;
-  margin-top: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 500;
-}
-
 /* features */
 
 .features {


### PR DESCRIPTION
Closes #19

Spec: .manager/specs/050-zvault-deploy.md

## Changes
- Makefile: add VERSION ldflags for version injection
- Release workflow: calls shared zarlcorp/.github go-release workflow on v* tags
- docs/index.html: remove "coming soon", add installation + quickstart
- docs/docs.html: full CLI command reference for all implemented commands
- README.md: installation, quickstart, all commands, config, dev
- Verified shell completions (bash, zsh, fish) output valid scripts
- CI already has build, vet, test — no changes needed
- main.go already has `var version = "dev"` — no changes needed