### PR TITLE
048: add TUI secret views with list, detail, and form

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/zarlcorp/zvault
 go 1.26.0
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -1,0 +1,40 @@
+package tui
+
+import (
+	"time"
+
+	"github.com/atotto/clipboard"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const clipboardClearDelay = 10 * time.Second
+
+// clipboardCopiedMsg signals that a value was copied.
+type clipboardCopiedMsg struct {
+	field string
+}
+
+// clipboardClearedMsg signals the auto-clear timer expired.
+type clipboardClearedMsg struct{}
+
+// copyToClipboard copies val to the system clipboard and schedules auto-clear.
+func copyToClipboard(field, val string) tea.Cmd {
+	return tea.Batch(
+		func() tea.Msg {
+			if err := clipboard.WriteAll(val); err != nil {
+				return errMsg{err: err}
+			}
+			return clipboardCopiedMsg{field: field}
+		},
+		scheduleClipboardClear(),
+	)
+}
+
+// scheduleClipboardClear returns a tick command that fires after the clear delay.
+func scheduleClipboardClear() tea.Cmd {
+	return tea.Tick(clipboardClearDelay, func(time.Time) tea.Msg {
+		// clear clipboard contents
+		_ = clipboard.WriteAll("")
+		return clipboardClearedMsg{}
+	})
+}

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -55,7 +55,18 @@ func helpFor(id viewID) []helpEntry {
 			{"enter", "select"},
 			{"q", "quit"},
 		}
-	case viewSecretList, viewTaskList:
+	case viewSecretList:
+		return []helpEntry{
+			{"↑/k", "up"},
+			{"↓/j", "down"},
+			{"enter", "open"},
+			{"n", "new"},
+			{"d", "delete"},
+			{"/", "search"},
+			{"tab", "filter"},
+			{"esc", "back"},
+		}
+	case viewTaskList:
 		return []helpEntry{
 			{"↑/k", "up"},
 			{"↓/j", "down"},
@@ -63,12 +74,29 @@ func helpFor(id viewID) []helpEntry {
 			{"esc", "back"},
 			{"q", "quit"},
 		}
-	case viewSecretDetail, viewTaskDetail:
+	case viewSecretDetail:
+		return []helpEntry{
+			{"↑/k", "up"},
+			{"↓/j", "down"},
+			{"c", "copy"},
+			{"s", "show/hide"},
+			{"e", "edit"},
+			{"d", "delete"},
+			{"esc", "back"},
+		}
+	case viewTaskDetail:
 		return []helpEntry{
 			{"esc", "back"},
 			{"q", "quit"},
 		}
-	case viewSecretForm, viewTaskForm:
+	case viewSecretForm:
+		return []helpEntry{
+			{"tab", "next"},
+			{"shift+tab", "prev"},
+			{"ctrl+s", "save"},
+			{"esc", "cancel"},
+		}
+	case viewTaskForm:
 		return []helpEntry{
 			{"tab", "next field"},
 			{"enter", "save"},

--- a/internal/tui/secret_detail.go
+++ b/internal/tui/secret_detail.go
@@ -1,0 +1,236 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/zarlcorp/core/pkg/zstyle"
+	"github.com/zarlcorp/zvault/internal/secret"
+	"github.com/zarlcorp/zvault/internal/vault"
+)
+
+// secretDetailModel displays a single secret's fields.
+type secretDetailModel struct {
+	vault    *vault.Vault
+	secret   secret.Secret
+	secretID string
+	showSensitive bool
+
+	// clipboard feedback
+	clipboardMsg string
+
+	// delete confirmation
+	confirmDelete bool
+
+	// field cursor for copy
+	cursor int
+	fields []detailField
+
+	width  int
+	height int
+}
+
+type detailField struct {
+	label     string
+	value     string
+	sensitive bool
+}
+
+func newSecretDetail() secretDetailModel {
+	return secretDetailModel{}
+}
+
+func (m secretDetailModel) load() secretDetailModel {
+	if m.vault == nil || m.secretID == "" {
+		return m
+	}
+	s, err := m.vault.Secrets().Get(m.secretID)
+	if err != nil {
+		return m
+	}
+	m.secret = s
+	m.fields = buildDetailFields(s)
+	if m.cursor >= len(m.fields) {
+		m.cursor = 0
+	}
+	return m
+}
+
+func buildDetailFields(s secret.Secret) []detailField {
+	var fields []detailField
+
+	fields = append(fields, detailField{label: "Name", value: s.Name})
+	fields = append(fields, detailField{label: "Type", value: string(s.Type)})
+
+	switch s.Type {
+	case secret.TypePassword:
+		fields = append(fields, detailField{label: "URL", value: s.URL()})
+		fields = append(fields, detailField{label: "Username", value: s.Username()})
+		fields = append(fields, detailField{label: "Password", value: s.Password(), sensitive: true})
+		if s.TOTPSecret() != "" {
+			fields = append(fields, detailField{label: "TOTP Secret", value: s.TOTPSecret(), sensitive: true})
+		}
+		if s.Notes() != "" {
+			fields = append(fields, detailField{label: "Notes", value: s.Notes()})
+		}
+	case secret.TypeAPIKey:
+		fields = append(fields, detailField{label: "Service", value: s.Service()})
+		fields = append(fields, detailField{label: "Key", value: s.Key(), sensitive: true})
+		if s.Notes() != "" {
+			fields = append(fields, detailField{label: "Notes", value: s.Notes()})
+		}
+	case secret.TypeSSHKey:
+		fields = append(fields, detailField{label: "Label", value: s.Label()})
+		fields = append(fields, detailField{label: "Private Key", value: s.PrivateKey(), sensitive: true})
+		fields = append(fields, detailField{label: "Public Key", value: s.PublicKey()})
+		if s.Passphrase() != "" {
+			fields = append(fields, detailField{label: "Passphrase", value: s.Passphrase(), sensitive: true})
+		}
+		if s.Notes() != "" {
+			fields = append(fields, detailField{label: "Notes", value: s.Notes()})
+		}
+	case secret.TypeNote:
+		fields = append(fields, detailField{label: "Content", value: s.Content()})
+	}
+
+	if len(s.Tags) > 0 {
+		fields = append(fields, detailField{label: "Tags", value: strings.Join(s.Tags, ", ")})
+	}
+
+	fields = append(fields, detailField{label: "Created", value: s.CreatedAt.Format("2006-01-02 15:04")})
+	fields = append(fields, detailField{label: "Updated", value: s.UpdatedAt.Format("2006-01-02 15:04")})
+
+	return fields
+}
+
+func (m secretDetailModel) Update(msg tea.Msg) (secretDetailModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case navigateMsg:
+		if msg.view == viewSecretDetail {
+			if id, ok := msg.data.(string); ok {
+				m.secretID = id
+				m.showSensitive = false
+				m.confirmDelete = false
+				m.clipboardMsg = ""
+				m.cursor = 0
+				m = m.load()
+			}
+		}
+		return m, nil
+
+	case clipboardCopiedMsg:
+		m.clipboardMsg = fmt.Sprintf("Copied %s! (clears in 10s)", msg.field)
+		return m, nil
+
+	case clipboardClearedMsg:
+		m.clipboardMsg = ""
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.confirmDelete {
+			return m.handleDeleteConfirm(msg)
+		}
+		return m.handleKeys(msg)
+	}
+	return m, nil
+}
+
+func (m secretDetailModel) handleDeleteConfirm(msg tea.KeyMsg) (secretDetailModel, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		if m.vault != nil {
+			if err := m.vault.Secrets().Delete(m.secretID); err != nil {
+				m.confirmDelete = false
+				return m, func() tea.Msg { return errMsg{err: err} }
+			}
+		}
+		m.confirmDelete = false
+		return m, func() tea.Msg { return navigateMsg{view: viewSecretList} }
+	case "n", "N", "esc":
+		m.confirmDelete = false
+	}
+	return m, nil
+}
+
+func (m secretDetailModel) handleKeys(msg tea.KeyMsg) (secretDetailModel, tea.Cmd) {
+	switch {
+	case key.Matches(msg, zstyle.KeyBack):
+		return m, func() tea.Msg { return navigateMsg{view: viewSecretList} }
+	case key.Matches(msg, zstyle.KeyUp):
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case key.Matches(msg, zstyle.KeyDown):
+		if m.cursor < len(m.fields)-1 {
+			m.cursor++
+		}
+	case msg.String() == "s":
+		m.showSensitive = !m.showSensitive
+	case msg.String() == "c":
+		if m.cursor < len(m.fields) {
+			f := m.fields[m.cursor]
+			return m, copyToClipboard(f.label, f.value)
+		}
+	case msg.String() == "e":
+		return m, func() tea.Msg {
+			return navigateMsg{view: viewSecretForm, data: m.secretID}
+		}
+	case msg.String() == "d":
+		m.confirmDelete = true
+	}
+	return m, nil
+}
+
+func (m secretDetailModel) View() string {
+	var b strings.Builder
+
+	if m.secretID == "" {
+		b.WriteString("\n")
+		b.WriteString(zstyle.MutedText.Render("  no secret selected"))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	labelStyle := lipgloss.NewStyle().Foreground(zstyle.Subtext1).Width(14)
+	valueStyle := lipgloss.NewStyle().Foreground(zstyle.Text)
+	maskedStyle := lipgloss.NewStyle().Foreground(zstyle.Surface2)
+	cursorStyle := lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent)
+
+	b.WriteString("\n")
+	for i, f := range m.fields {
+		prefix := "  "
+		if i == m.cursor {
+			prefix = cursorStyle.Render("▸ ")
+		}
+
+		label := labelStyle.Render(f.label)
+		var val string
+		if f.sensitive && !m.showSensitive {
+			val = maskedStyle.Render("••••••••")
+		} else {
+			val = valueStyle.Render(f.value)
+		}
+
+		b.WriteString(fmt.Sprintf("  %s%s  %s\n", prefix, label, val))
+	}
+
+	// delete confirmation
+	if m.confirmDelete {
+		warn := lipgloss.NewStyle().Foreground(zstyle.Warning)
+		b.WriteString("\n")
+		b.WriteString(warn.Render(fmt.Sprintf("  Delete '%s'? (y/n)", m.secret.Name)))
+		b.WriteString("\n")
+	}
+
+	// clipboard status
+	if m.clipboardMsg != "" {
+		b.WriteString("\n")
+		b.WriteString(zstyle.StatusOK.Render("  " + m.clipboardMsg))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/tui/secret_detail_test.go
+++ b/internal/tui/secret_detail_test.go
@@ -1,0 +1,284 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zarlcorp/zvault/internal/secret"
+)
+
+func TestSecretDetailViewNoSecret(t *testing.T) {
+	m := newSecretDetail()
+	view := m.View()
+	if !strings.Contains(view, "no secret selected") {
+		t.Error("empty detail should show 'no secret selected'")
+	}
+}
+
+func TestSecretDetailEscNavigatesBack(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc should produce a navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewSecretList {
+		t.Fatalf("nav view = %d, want viewSecretList", nav.view)
+	}
+}
+
+func TestSecretDetailToggleSensitive(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+	m.secret = secret.NewPassword("test", "http://example.com", "user", "pass123")
+	m.fields = buildDetailFields(m.secret)
+
+	if m.showSensitive {
+		t.Fatal("should start with sensitive fields hidden")
+	}
+
+	// toggle with s
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if !m.showSensitive {
+		t.Fatal("s should toggle sensitive fields to visible")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if m.showSensitive {
+		t.Fatal("s should toggle sensitive fields back to hidden")
+	}
+}
+
+func TestSecretDetailSensitiveMasked(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+	m.secret = secret.NewPassword("test", "http://example.com", "user", "secretpass")
+	m.fields = buildDetailFields(m.secret)
+	m.showSensitive = false
+
+	view := m.View()
+	if strings.Contains(view, "secretpass") {
+		t.Error("password should be masked when showSensitive is false")
+	}
+	if !strings.Contains(view, "••••••••") {
+		t.Error("masked value should show dots")
+	}
+}
+
+func TestSecretDetailSensitiveRevealed(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+	m.secret = secret.NewPassword("test", "http://example.com", "user", "secretpass")
+	m.fields = buildDetailFields(m.secret)
+	m.showSensitive = true
+
+	view := m.View()
+	if !strings.Contains(view, "secretpass") {
+		t.Error("password should be visible when showSensitive is true")
+	}
+}
+
+func TestSecretDetailCursorNavigation(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+	m.secret = secret.NewPassword("test", "http://example.com", "user", "pass")
+	m.fields = buildDetailFields(m.secret)
+	m.cursor = 0
+
+	// move down
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1", m.cursor)
+	}
+
+	// move up
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if m.cursor != 0 {
+		t.Fatalf("cursor = %d, want 0", m.cursor)
+	}
+
+	// can't go below 0
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if m.cursor != 0 {
+		t.Fatalf("cursor = %d, want 0 (bounded)", m.cursor)
+	}
+}
+
+func TestSecretDetailDeleteConfirmation(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+	m.secret = secret.NewPassword("MyPass", "", "", "")
+	m.fields = buildDetailFields(m.secret)
+
+	// d triggers confirm
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if !m.confirmDelete {
+		t.Fatal("d should trigger delete confirmation")
+	}
+
+	// n cancels
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.confirmDelete {
+		t.Fatal("n should cancel delete confirmation")
+	}
+}
+
+func TestSecretDetailDeleteConfirmView(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+	m.secret = secret.NewPassword("MyPass", "", "", "")
+	m.fields = buildDetailFields(m.secret)
+	m.confirmDelete = true
+
+	view := m.View()
+	if !strings.Contains(view, "Delete 'MyPass'? (y/n)") {
+		t.Error("delete confirmation should show secret name")
+	}
+}
+
+func TestSecretDetailEditNavigatesToForm(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "abc123"
+	m.fields = buildDetailFields(secret.NewPassword("test", "", "", ""))
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd == nil {
+		t.Fatal("e should produce a navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewSecretForm {
+		t.Fatalf("nav view = %d, want viewSecretForm", nav.view)
+	}
+	if nav.data != "abc123" {
+		t.Fatalf("nav data = %v, want 'abc123'", nav.data)
+	}
+}
+
+func TestSecretDetailClipboardMsg(t *testing.T) {
+	m := newSecretDetail()
+	m.secretID = "test"
+
+	m, _ = m.Update(clipboardCopiedMsg{field: "Password"})
+	if !strings.Contains(m.clipboardMsg, "Copied Password") {
+		t.Fatalf("clipboardMsg = %q, want 'Copied Password...'", m.clipboardMsg)
+	}
+
+	m, _ = m.Update(clipboardClearedMsg{})
+	if m.clipboardMsg != "" {
+		t.Fatalf("clipboardMsg should be cleared, got %q", m.clipboardMsg)
+	}
+}
+
+func TestBuildDetailFieldsPassword(t *testing.T) {
+	s := secret.NewPassword("Test", "http://example.com", "user", "pass123")
+	s.Fields["totp_secret"] = "JBSWY3DPEHPK3PXP"
+	s.Fields["notes"] = "my notes"
+	s.Tags = []string{"web", "dev"}
+	fields := buildDetailFields(s)
+
+	labels := make(map[string]bool)
+	for _, f := range fields {
+		labels[f.label] = true
+	}
+	for _, want := range []string{"Name", "Type", "URL", "Username", "Password", "TOTP Secret", "Notes", "Tags", "Created", "Updated"} {
+		if !labels[want] {
+			t.Errorf("missing field %q", want)
+		}
+	}
+
+	// check sensitive flags
+	for _, f := range fields {
+		switch f.label {
+		case "Password", "TOTP Secret":
+			if !f.sensitive {
+				t.Errorf("field %q should be sensitive", f.label)
+			}
+		case "Name", "URL", "Username":
+			if f.sensitive {
+				t.Errorf("field %q should not be sensitive", f.label)
+			}
+		}
+	}
+}
+
+func TestBuildDetailFieldsAPIKey(t *testing.T) {
+	s := secret.NewAPIKey("AWS", "aws", "AKIA1234")
+	fields := buildDetailFields(s)
+
+	var foundKey bool
+	for _, f := range fields {
+		if f.label == "Key" {
+			foundKey = true
+			if !f.sensitive {
+				t.Error("Key field should be sensitive")
+			}
+		}
+	}
+	if !foundKey {
+		t.Error("API key should have Key field")
+	}
+}
+
+func TestBuildDetailFieldsSSHKey(t *testing.T) {
+	s := secret.NewSSHKey("Server", "prod", "-----BEGIN-----", "ssh-rsa AAAA")
+	s.Fields["passphrase"] = "secret"
+	fields := buildDetailFields(s)
+
+	sensitiveLabels := make(map[string]bool)
+	for _, f := range fields {
+		if f.sensitive {
+			sensitiveLabels[f.label] = true
+		}
+	}
+	if !sensitiveLabels["Private Key"] {
+		t.Error("Private Key should be sensitive")
+	}
+	if !sensitiveLabels["Passphrase"] {
+		t.Error("Passphrase should be sensitive")
+	}
+}
+
+func TestBuildDetailFieldsNote(t *testing.T) {
+	s := secret.NewNote("Ideas", "some content")
+	fields := buildDetailFields(s)
+
+	var foundContent bool
+	for _, f := range fields {
+		if f.label == "Content" {
+			foundContent = true
+			if f.value != "some content" {
+				t.Errorf("Content value = %q, want 'some content'", f.value)
+			}
+		}
+	}
+	if !foundContent {
+		t.Error("Note should have Content field")
+	}
+}
+
+func TestBuildDetailFieldsMetadata(t *testing.T) {
+	s := secret.NewPassword("test", "", "", "")
+	s.CreatedAt = time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	s.UpdatedAt = time.Date(2026, 2, 18, 14, 0, 0, 0, time.UTC)
+	fields := buildDetailFields(s)
+
+	for _, f := range fields {
+		if f.label == "Created" && !strings.Contains(f.value, "2026-01-15") {
+			t.Errorf("Created = %q, want date containing '2026-01-15'", f.value)
+		}
+		if f.label == "Updated" && !strings.Contains(f.value, "2026-02-18") {
+			t.Errorf("Updated = %q, want date containing '2026-02-18'", f.value)
+		}
+	}
+}

--- a/internal/tui/secret_form.go
+++ b/internal/tui/secret_form.go
@@ -1,0 +1,495 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/zarlcorp/core/pkg/zstyle"
+	"github.com/zarlcorp/zvault/internal/secret"
+	"github.com/zarlcorp/zvault/internal/vault"
+)
+
+// formMode indicates create vs edit.
+type formMode int
+
+const (
+	formCreate formMode = iota
+	formEdit
+)
+
+// secretFormModel handles create/edit of secrets.
+type secretFormModel struct {
+	vault    *vault.Vault
+	mode     formMode
+	editID   string // set in edit mode
+	secType  secret.Type
+	typeSel  int // index in typeOptions (create only)
+	inputs   []formInput
+	focused  int
+	changed  bool
+	err      string
+
+	// confirm discard on esc if changed
+	confirmDiscard bool
+
+	width  int
+	height int
+}
+
+type formInput struct {
+	label    string
+	fieldKey string
+	input    textinput.Model
+	masked   bool
+}
+
+var typeOptions = []secret.Type{
+	secret.TypePassword,
+	secret.TypeAPIKey,
+	secret.TypeSSHKey,
+	secret.TypeNote,
+}
+
+func typeLabel(t secret.Type) string {
+	switch t {
+	case secret.TypePassword:
+		return "Password"
+	case secret.TypeAPIKey:
+		return "API Key"
+	case secret.TypeSSHKey:
+		return "SSH Key"
+	case secret.TypeNote:
+		return "Note"
+	}
+	return string(t)
+}
+
+func newSecretForm() secretFormModel {
+	return secretFormModel{
+		secType: secret.TypePassword,
+	}
+}
+
+func (m secretFormModel) initForCreate() secretFormModel {
+	m.mode = formCreate
+	m.editID = ""
+	m.typeSel = 0
+	m.secType = typeOptions[0]
+	m.changed = false
+	m.err = ""
+	m.confirmDiscard = false
+	m.inputs = buildFormInputs(m.secType, secret.Secret{})
+	m.focused = 0
+	m.focusCurrent()
+	return m
+}
+
+func (m secretFormModel) initForEdit(id string) secretFormModel {
+	m.mode = formEdit
+	m.editID = id
+	m.changed = false
+	m.err = ""
+	m.confirmDiscard = false
+
+	if m.vault == nil {
+		return m
+	}
+
+	s, err := m.vault.Secrets().Get(id)
+	if err != nil {
+		m.err = err.Error()
+		return m
+	}
+
+	m.secType = s.Type
+	for i, t := range typeOptions {
+		if t == s.Type {
+			m.typeSel = i
+			break
+		}
+	}
+	m.inputs = buildFormInputs(s.Type, s)
+	m.focused = 0
+	m.focusCurrent()
+	return m
+}
+
+func buildFormInputs(t secret.Type, s secret.Secret) []formInput {
+	var inputs []formInput
+
+	addInput := func(label, fieldKey, value string, masked bool) {
+		ti := textinput.New()
+		ti.Placeholder = label
+		ti.PromptStyle = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent)
+		ti.TextStyle = lipgloss.NewStyle().Foreground(zstyle.Text)
+		if masked {
+			ti.EchoMode = textinput.EchoPassword
+			ti.EchoCharacter = '•'
+		}
+		ti.SetValue(value)
+		inputs = append(inputs, formInput{
+			label:    label,
+			fieldKey: fieldKey,
+			input:    ti,
+			masked:   masked,
+		})
+	}
+
+	// name is always first
+	addInput("Name", "name", s.Name, false)
+
+	switch t {
+	case secret.TypePassword:
+		addInput("URL", "url", s.URL(), false)
+		addInput("Username", "username", s.Username(), false)
+		addInput("Password", "password", s.Password(), true)
+		addInput("TOTP Secret", "totp_secret", s.TOTPSecret(), true)
+		addInput("Notes", "notes", s.Notes(), false)
+	case secret.TypeAPIKey:
+		addInput("Service", "service", s.Service(), false)
+		addInput("Key", "key", s.Key(), true)
+		addInput("Notes", "notes", s.Notes(), false)
+	case secret.TypeSSHKey:
+		addInput("Label", "label", s.Label(), false)
+		addInput("Private Key", "private_key", s.PrivateKey(), true)
+		addInput("Public Key", "public_key", s.PublicKey(), false)
+		addInput("Passphrase", "passphrase", s.Passphrase(), true)
+		addInput("Notes", "notes", s.Notes(), false)
+	case secret.TypeNote:
+		addInput("Content", "content", s.Content(), false)
+	}
+
+	// tags always last
+	tags := ""
+	if len(s.Tags) > 0 {
+		tags = strings.Join(s.Tags, ", ")
+	}
+	addInput("Tags", "tags", tags, false)
+
+	return inputs
+}
+
+func (m *secretFormModel) focusCurrent() {
+	for i := range m.inputs {
+		if i == m.focused {
+			m.inputs[i].input.Focus()
+		} else {
+			m.inputs[i].input.Blur()
+		}
+	}
+}
+
+func (m secretFormModel) Update(msg tea.Msg) (secretFormModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case navigateMsg:
+		if msg.view == viewSecretForm {
+			if msg.data == nil {
+				m = m.initForCreate()
+				return m, textinput.Blink
+			}
+			if id, ok := msg.data.(string); ok {
+				m = m.initForEdit(id)
+				return m, textinput.Blink
+			}
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.confirmDiscard {
+			return m.handleDiscardConfirm(msg)
+		}
+		return m.handleKeys(msg)
+	}
+
+	// pass to focused input
+	if m.focused < len(m.inputs) {
+		var cmd tea.Cmd
+		m.inputs[m.focused].input, cmd = m.inputs[m.focused].input.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m secretFormModel) handleDiscardConfirm(msg tea.KeyMsg) (secretFormModel, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		m.confirmDiscard = false
+		return m, func() tea.Msg { return navigateMsg{view: viewSecretList} }
+	case "n", "N", "esc":
+		m.confirmDiscard = false
+	}
+	return m, nil
+}
+
+func (m secretFormModel) handleKeys(msg tea.KeyMsg) (secretFormModel, tea.Cmd) {
+	switch {
+	case msg.Type == tea.KeyCtrlS:
+		return m.save()
+
+	case key.Matches(msg, zstyle.KeyBack):
+		if m.changed {
+			m.confirmDiscard = true
+			return m, nil
+		}
+		return m, func() tea.Msg { return navigateMsg{view: viewSecretList} }
+
+	case msg.Type == tea.KeyShiftTab:
+		m.changed = true
+		if m.focused > 0 {
+			m.focused--
+			m.focusCurrent()
+		}
+		return m, nil
+
+	case key.Matches(msg, zstyle.KeyTab):
+		m.changed = true
+		if m.focused < len(m.inputs)-1 {
+			m.focused++
+			m.focusCurrent()
+		}
+		return m, nil
+
+	case key.Matches(msg, zstyle.KeyEnter):
+		// enter on last field saves
+		if m.focused == len(m.inputs)-1 {
+			return m.save()
+		}
+		// otherwise, next field
+		m.changed = true
+		if m.focused < len(m.inputs)-1 {
+			m.focused++
+			m.focusCurrent()
+		}
+		return m, nil
+
+	case msg.String() == "left" && m.mode == formCreate && m.focused == 0:
+		// cycle type backward
+		if m.typeSel > 0 {
+			m.typeSel--
+		} else {
+			m.typeSel = len(typeOptions) - 1
+		}
+		m.secType = typeOptions[m.typeSel]
+		m.rebuildInputsPreserveName()
+		return m, nil
+
+	case msg.String() == "right" && m.mode == formCreate && m.focused == 0:
+		// cycle type forward
+		m.typeSel = (m.typeSel + 1) % len(typeOptions)
+		m.secType = typeOptions[m.typeSel]
+		m.rebuildInputsPreserveName()
+		return m, nil
+	}
+
+	// pass to focused input
+	if m.focused < len(m.inputs) {
+		var cmd tea.Cmd
+		old := m.inputs[m.focused].input.Value()
+		m.inputs[m.focused].input, cmd = m.inputs[m.focused].input.Update(msg)
+		if m.inputs[m.focused].input.Value() != old {
+			m.changed = true
+		}
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *secretFormModel) rebuildInputsPreserveName() {
+	// preserve name value
+	name := ""
+	if len(m.inputs) > 0 {
+		name = m.inputs[0].input.Value()
+	}
+	m.inputs = buildFormInputs(m.secType, secret.Secret{})
+	if len(m.inputs) > 0 {
+		m.inputs[0].input.SetValue(name)
+	}
+	if m.focused >= len(m.inputs) {
+		m.focused = 0
+	}
+	m.focusCurrent()
+}
+
+func (m secretFormModel) save() (secretFormModel, tea.Cmd) {
+	// collect values
+	vals := make(map[string]string)
+	for _, inp := range m.inputs {
+		vals[inp.fieldKey] = inp.input.Value()
+	}
+
+	name := strings.TrimSpace(vals["name"])
+	if name == "" {
+		m.err = "name is required"
+		return m, nil
+	}
+
+	// parse tags
+	var tags []string
+	if t := strings.TrimSpace(vals["tags"]); t != "" {
+		for _, tag := range strings.Split(t, ",") {
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				tags = append(tags, tag)
+			}
+		}
+	}
+
+	if m.mode == formCreate {
+		return m.createSecret(name, vals, tags)
+	}
+	return m.updateSecret(name, vals, tags)
+}
+
+func (m secretFormModel) createSecret(name string, vals map[string]string, tags []string) (secretFormModel, tea.Cmd) {
+	var s secret.Secret
+	switch m.secType {
+	case secret.TypePassword:
+		s = secret.NewPassword(name, vals["url"], vals["username"], vals["password"])
+		if v := vals["totp_secret"]; v != "" {
+			s.Fields["totp_secret"] = v
+		}
+		if v := vals["notes"]; v != "" {
+			s.Fields["notes"] = v
+		}
+	case secret.TypeAPIKey:
+		s = secret.NewAPIKey(name, vals["service"], vals["key"])
+		if v := vals["notes"]; v != "" {
+			s.Fields["notes"] = v
+		}
+	case secret.TypeSSHKey:
+		s = secret.NewSSHKey(name, vals["label"], vals["private_key"], vals["public_key"])
+		if v := vals["passphrase"]; v != "" {
+			s.Fields["passphrase"] = v
+		}
+		if v := vals["notes"]; v != "" {
+			s.Fields["notes"] = v
+		}
+	case secret.TypeNote:
+		s = secret.NewNote(name, vals["content"])
+	}
+	s.Tags = tags
+
+	if m.vault != nil {
+		if err := m.vault.Secrets().Add(s); err != nil {
+			m.err = err.Error()
+			return m, nil
+		}
+	}
+
+	return m, func() tea.Msg {
+		return navigateMsg{view: viewSecretList}
+	}
+}
+
+func (m secretFormModel) updateSecret(name string, vals map[string]string, tags []string) (secretFormModel, tea.Cmd) {
+	if m.vault == nil {
+		return m, func() tea.Msg { return navigateMsg{view: viewSecretList} }
+	}
+
+	s, err := m.vault.Secrets().Get(m.editID)
+	if err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+
+	s.Name = name
+	s.Tags = tags
+
+	// update fields based on type
+	switch s.Type {
+	case secret.TypePassword:
+		s.Fields["url"] = vals["url"]
+		s.Fields["username"] = vals["username"]
+		s.Fields["password"] = vals["password"]
+		s.Fields["totp_secret"] = vals["totp_secret"]
+		s.Fields["notes"] = vals["notes"]
+	case secret.TypeAPIKey:
+		s.Fields["service"] = vals["service"]
+		s.Fields["key"] = vals["key"]
+		s.Fields["notes"] = vals["notes"]
+	case secret.TypeSSHKey:
+		s.Fields["label"] = vals["label"]
+		s.Fields["private_key"] = vals["private_key"]
+		s.Fields["public_key"] = vals["public_key"]
+		s.Fields["passphrase"] = vals["passphrase"]
+		s.Fields["notes"] = vals["notes"]
+	case secret.TypeNote:
+		s.Fields["content"] = vals["content"]
+	}
+
+	if err := m.vault.Secrets().Update(s); err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+
+	return m, func() tea.Msg {
+		return navigateMsg{view: viewSecretList}
+	}
+}
+
+func (m secretFormModel) View() string {
+	var b strings.Builder
+
+	b.WriteString("\n")
+
+	// type selector (create only)
+	if m.mode == formCreate {
+		typeLbl := lipgloss.NewStyle().Foreground(zstyle.Subtext1).Render("Type")
+		b.WriteString(fmt.Sprintf("  %s  ", typeLbl))
+		for i, t := range typeOptions {
+			label := typeLabel(t)
+			if i == m.typeSel {
+				style := lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent).Bold(true)
+				b.WriteString(style.Render(label))
+			} else {
+				style := lipgloss.NewStyle().Foreground(zstyle.Overlay1)
+				b.WriteString(style.Render(label))
+			}
+			if i < len(typeOptions)-1 {
+				b.WriteString(lipgloss.NewStyle().Foreground(zstyle.Surface2).Render(" | "))
+			}
+		}
+		hint := zstyle.MutedText.Render("  (←/→ to change)")
+		b.WriteString(hint)
+		b.WriteString("\n\n")
+	}
+
+	// form fields
+	labelStyle := lipgloss.NewStyle().Foreground(zstyle.Subtext1)
+	cursorActive := lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent).Render("▸ ")
+	cursorInactive := "  "
+
+	for i, inp := range m.inputs {
+		cursor := cursorInactive
+		if i == m.focused {
+			cursor = cursorActive
+		}
+		label := labelStyle.Render(inp.label)
+		b.WriteString(fmt.Sprintf("  %s%s\n", cursor, label))
+		b.WriteString(fmt.Sprintf("    %s\n", inp.input.View()))
+		if i < len(m.inputs)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	// confirm discard
+	if m.confirmDiscard {
+		warn := lipgloss.NewStyle().Foreground(zstyle.Warning)
+		b.WriteString("\n")
+		b.WriteString(warn.Render("  Discard changes? (y/n)"))
+		b.WriteString("\n")
+	}
+
+	// error
+	if m.err != "" {
+		b.WriteString("\n")
+		b.WriteString(zstyle.StatusErr.Render("  " + m.err))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/tui/secret_form_test.go
+++ b/internal/tui/secret_form_test.go
@@ -1,0 +1,320 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zarlcorp/zvault/internal/secret"
+)
+
+func TestSecretFormInitForCreate(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+
+	if m.mode != formCreate {
+		t.Fatalf("mode = %d, want formCreate", m.mode)
+	}
+	if m.secType != secret.TypePassword {
+		t.Fatalf("secType = %q, want TypePassword", m.secType)
+	}
+	if len(m.inputs) == 0 {
+		t.Fatal("should have form inputs")
+	}
+	// first input should be name
+	if m.inputs[0].fieldKey != "name" {
+		t.Fatalf("first input = %q, want 'name'", m.inputs[0].fieldKey)
+	}
+	// last input should be tags
+	last := m.inputs[len(m.inputs)-1]
+	if last.fieldKey != "tags" {
+		t.Fatalf("last input = %q, want 'tags'", last.fieldKey)
+	}
+}
+
+func TestSecretFormPasswordFields(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	m.secType = secret.TypePassword
+	m.inputs = buildFormInputs(secret.TypePassword, secret.Secret{})
+
+	keys := make(map[string]bool)
+	for _, inp := range m.inputs {
+		keys[inp.fieldKey] = true
+	}
+	for _, want := range []string{"name", "url", "username", "password", "totp_secret", "notes", "tags"} {
+		if !keys[want] {
+			t.Errorf("missing field %q for password type", want)
+		}
+	}
+}
+
+func TestSecretFormAPIKeyFields(t *testing.T) {
+	inputs := buildFormInputs(secret.TypeAPIKey, secret.Secret{})
+	keys := make(map[string]bool)
+	for _, inp := range inputs {
+		keys[inp.fieldKey] = true
+	}
+	for _, want := range []string{"name", "service", "key", "notes", "tags"} {
+		if !keys[want] {
+			t.Errorf("missing field %q for apikey type", want)
+		}
+	}
+}
+
+func TestSecretFormSSHKeyFields(t *testing.T) {
+	inputs := buildFormInputs(secret.TypeSSHKey, secret.Secret{})
+	keys := make(map[string]bool)
+	for _, inp := range inputs {
+		keys[inp.fieldKey] = true
+	}
+	for _, want := range []string{"name", "label", "private_key", "public_key", "passphrase", "notes", "tags"} {
+		if !keys[want] {
+			t.Errorf("missing field %q for sshkey type", want)
+		}
+	}
+}
+
+func TestSecretFormNoteFields(t *testing.T) {
+	inputs := buildFormInputs(secret.TypeNote, secret.Secret{})
+	keys := make(map[string]bool)
+	for _, inp := range inputs {
+		keys[inp.fieldKey] = true
+	}
+	for _, want := range []string{"name", "content", "tags"} {
+		if !keys[want] {
+			t.Errorf("missing field %q for note type", want)
+		}
+	}
+}
+
+func TestSecretFormMaskedFields(t *testing.T) {
+	inputs := buildFormInputs(secret.TypePassword, secret.Secret{})
+	masked := make(map[string]bool)
+	for _, inp := range inputs {
+		if inp.masked {
+			masked[inp.fieldKey] = true
+		}
+	}
+	if !masked["password"] {
+		t.Error("password field should be masked")
+	}
+	if !masked["totp_secret"] {
+		t.Error("totp_secret field should be masked")
+	}
+	if masked["name"] {
+		t.Error("name field should not be masked")
+	}
+}
+
+func TestSecretFormTabNavigation(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+
+	if m.focused != 0 {
+		t.Fatalf("focused = %d, want 0", m.focused)
+	}
+
+	// tab moves to next field
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.focused != 1 {
+		t.Fatalf("focused = %d, want 1 after tab", m.focused)
+	}
+
+	// shift+tab moves back
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if m.focused != 0 {
+		t.Fatalf("focused = %d, want 0 after shift+tab", m.focused)
+	}
+
+	// shift+tab at 0 stays at 0
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if m.focused != 0 {
+		t.Fatalf("focused = %d, want 0 (bounded)", m.focused)
+	}
+}
+
+func TestSecretFormEscNoChanges(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	m.changed = false
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc without changes should navigate back immediately")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewSecretList {
+		t.Fatalf("nav view = %d, want viewSecretList", nav.view)
+	}
+}
+
+func TestSecretFormEscWithChangesConfirm(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	m.changed = true
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd != nil {
+		t.Fatal("esc with changes should show confirmation, not navigate")
+	}
+	if !m.confirmDiscard {
+		t.Fatal("should show discard confirmation")
+	}
+
+	// confirm with y
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("y should navigate back")
+	}
+}
+
+func TestSecretFormEscWithChangesDeny(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	m.changed = true
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if !m.confirmDiscard {
+		t.Fatal("should show discard confirmation")
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.confirmDiscard {
+		t.Fatal("n should dismiss discard confirmation")
+	}
+}
+
+func TestSecretFormSaveEmptyName(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	// don't set name, just try ctrl+s
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if m.err != "name is required" {
+		t.Fatalf("err = %q, want 'name is required'", m.err)
+	}
+}
+
+func TestSecretFormViewShowsTypeSelector(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	view := m.View()
+	if !strings.Contains(view, "Password") {
+		t.Error("create form should show type selector with Password")
+	}
+	if !strings.Contains(view, "API Key") {
+		t.Error("create form should show type selector with API Key")
+	}
+}
+
+func TestSecretFormViewShowsFields(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	view := m.View()
+	if !strings.Contains(view, "Name") {
+		t.Error("form should show Name field")
+	}
+	if !strings.Contains(view, "URL") {
+		t.Error("password form should show URL field")
+	}
+	if !strings.Contains(view, "Username") {
+		t.Error("password form should show Username field")
+	}
+}
+
+func TestSecretFormConfirmDiscardView(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	m.confirmDiscard = true
+
+	view := m.View()
+	if !strings.Contains(view, "Discard changes? (y/n)") {
+		t.Error("should show discard confirmation")
+	}
+}
+
+func TestSecretFormErrorView(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	m.err = "test error"
+
+	view := m.View()
+	if !strings.Contains(view, "test error") {
+		t.Error("should show error message")
+	}
+}
+
+func TestSecretFormNavigateInitCreate(t *testing.T) {
+	m := newSecretForm()
+	m, _ = m.Update(navigateMsg{view: viewSecretForm, data: nil})
+	if m.mode != formCreate {
+		t.Fatalf("mode = %d, want formCreate", m.mode)
+	}
+}
+
+func TestSecretFormNavigateInitEdit(t *testing.T) {
+	m := newSecretForm()
+	m, _ = m.Update(navigateMsg{view: viewSecretForm, data: "abc123"})
+	if m.mode != formEdit {
+		t.Fatalf("mode = %d, want formEdit", m.mode)
+	}
+	if m.editID != "abc123" {
+		t.Fatalf("editID = %q, want 'abc123'", m.editID)
+	}
+}
+
+func TestSecretFormEnterOnLastFieldSaves(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	// move to last field
+	m.focused = len(m.inputs) - 1
+	m.focusCurrent()
+	// set a name so save doesn't fail on validation
+	m.inputs[0].input.SetValue("Test Secret")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on last field should save (produce navigate command)")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewSecretList {
+		t.Fatalf("nav view = %d, want viewSecretList after save", nav.view)
+	}
+}
+
+func TestSecretFormEnterOnNonLastFieldAdvances(t *testing.T) {
+	m := newSecretForm()
+	m = m.initForCreate()
+	m.focused = 0
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.focused != 1 {
+		t.Fatalf("focused = %d, want 1 after enter on non-last field", m.focused)
+	}
+}
+
+func TestTypeLabel(t *testing.T) {
+	tests := []struct {
+		typ  secret.Type
+		want string
+	}{
+		{secret.TypePassword, "Password"},
+		{secret.TypeAPIKey, "API Key"},
+		{secret.TypeSSHKey, "SSH Key"},
+		{secret.TypeNote, "Note"},
+	}
+	for _, tt := range tests {
+		got := typeLabel(tt.typ)
+		if got != tt.want {
+			t.Errorf("typeLabel(%s) = %q, want %q", tt.typ, got, tt.want)
+		}
+	}
+}

--- a/internal/tui/secret_list.go
+++ b/internal/tui/secret_list.go
@@ -1,0 +1,348 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/zarlcorp/core/pkg/zstyle"
+	"github.com/zarlcorp/zvault/internal/secret"
+	"github.com/zarlcorp/zvault/internal/vault"
+)
+
+// typeFilter enumerates the type filter options.
+type typeFilter int
+
+const (
+	filterAll typeFilter = iota
+	filterPassword
+	filterAPIKey
+	filterSSHKey
+	filterNote
+	filterCount // sentinel
+)
+
+func (f typeFilter) label() string {
+	switch f {
+	case filterAll:
+		return "All"
+	case filterPassword:
+		return "Password"
+	case filterAPIKey:
+		return "API Key"
+	case filterSSHKey:
+		return "SSH Key"
+	case filterNote:
+		return "Note"
+	}
+	return ""
+}
+
+func (f typeFilter) secretType() secret.Type {
+	switch f {
+	case filterPassword:
+		return secret.TypePassword
+	case filterAPIKey:
+		return secret.TypeAPIKey
+	case filterSSHKey:
+		return secret.TypeSSHKey
+	case filterNote:
+		return secret.TypeNote
+	}
+	return ""
+}
+
+// secretListModel displays a scrollable, filterable list of secrets.
+type secretListModel struct {
+	vault   *vault.Vault
+	secrets []secret.Secret // current filtered set
+	cursor  int
+	filter  typeFilter
+
+	// search
+	searching bool
+	search    textinput.Model
+
+	// delete confirmation
+	confirmDelete bool
+
+	// status message
+	status string
+
+	width  int
+	height int
+}
+
+func newSecretList() secretListModel {
+	si := textinput.New()
+	si.Placeholder = "search..."
+	si.PromptStyle = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent)
+	si.TextStyle = lipgloss.NewStyle().Foreground(zstyle.Text)
+	return secretListModel{search: si}
+}
+
+func (m secretListModel) loadSecrets() secretListModel {
+	if m.vault == nil {
+		m.secrets = nil
+		return m
+	}
+
+	var all []secret.Secret
+	var err error
+
+	query := m.search.Value()
+	if m.searching && query != "" {
+		all, err = m.vault.Secrets().Search(query)
+	} else {
+		all, err = m.vault.Secrets().List()
+	}
+	if err != nil {
+		m.secrets = nil
+		return m
+	}
+
+	// apply type filter
+	if m.filter != filterAll {
+		ft := m.filter.secretType()
+		var filtered []secret.Secret
+		for _, s := range all {
+			if s.Type == ft {
+				filtered = append(filtered, s)
+			}
+		}
+		all = filtered
+	}
+
+	m.secrets = all
+	if m.cursor >= len(m.secrets) {
+		m.cursor = max(0, len(m.secrets)-1)
+	}
+	return m
+}
+
+func (m secretListModel) Update(msg tea.Msg) (secretListModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case navigateMsg:
+		// refresh when navigated to
+		if msg.view == viewSecretList {
+			m.confirmDelete = false
+			m.status = ""
+			m = m.loadSecrets()
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		// handle delete confirmation
+		if m.confirmDelete {
+			return m.handleDeleteConfirm(msg)
+		}
+
+		// handle search mode input
+		if m.searching {
+			return m.handleSearchInput(msg)
+		}
+
+		return m.handleNormalKeys(msg)
+	}
+	return m, nil
+}
+
+func (m secretListModel) handleDeleteConfirm(msg tea.KeyMsg) (secretListModel, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		if m.cursor < len(m.secrets) {
+			s := m.secrets[m.cursor]
+			if m.vault != nil {
+				if err := m.vault.Secrets().Delete(s.ID); err != nil {
+					m.confirmDelete = false
+					return m, func() tea.Msg { return errMsg{err: err} }
+				}
+			}
+			m.status = fmt.Sprintf("deleted '%s'", s.Name)
+			m.confirmDelete = false
+			m = m.loadSecrets()
+		}
+	case "n", "N", "esc":
+		m.confirmDelete = false
+	}
+	return m, nil
+}
+
+func (m secretListModel) handleSearchInput(msg tea.KeyMsg) (secretListModel, tea.Cmd) {
+	switch {
+	case key.Matches(msg, zstyle.KeyBack):
+		m.searching = false
+		m.search.Blur()
+		m.search.SetValue("")
+		m = m.loadSecrets()
+		return m, nil
+	case key.Matches(msg, zstyle.KeyEnter):
+		m.searching = false
+		m.search.Blur()
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.search, cmd = m.search.Update(msg)
+	m = m.loadSecrets()
+	return m, cmd
+}
+
+func (m secretListModel) handleNormalKeys(msg tea.KeyMsg) (secretListModel, tea.Cmd) {
+	switch {
+	case key.Matches(msg, zstyle.KeyUp):
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case key.Matches(msg, zstyle.KeyDown):
+		if m.cursor < len(m.secrets)-1 {
+			m.cursor++
+		}
+	case key.Matches(msg, zstyle.KeyEnter):
+		if m.cursor < len(m.secrets) {
+			s := m.secrets[m.cursor]
+			return m, func() tea.Msg {
+				return navigateMsg{view: viewSecretDetail, data: s.ID}
+			}
+		}
+	case key.Matches(msg, zstyle.KeyBack):
+		parent := parentView(viewSecretList)
+		return m, func() tea.Msg { return navigateMsg{view: parent} }
+	case key.Matches(msg, zstyle.KeyFilter):
+		m.searching = true
+		m.search.Focus()
+		m.status = ""
+		return m, textinput.Blink
+	case msg.String() == "tab":
+		m.filter = (m.filter + 1) % filterCount
+		m.status = ""
+		m = m.loadSecrets()
+	case msg.String() == "n":
+		return m, func() tea.Msg {
+			return navigateMsg{view: viewSecretForm, data: nil}
+		}
+	case msg.String() == "d":
+		if len(m.secrets) > 0 && m.cursor < len(m.secrets) {
+			m.confirmDelete = true
+			m.status = ""
+		}
+	}
+	return m, nil
+}
+
+func (m secretListModel) View() string {
+	var b strings.Builder
+
+	// filter tabs
+	b.WriteString("\n  ")
+	for i := typeFilter(0); i < filterCount; i++ {
+		label := i.label()
+		if i == m.filter {
+			style := lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent).Bold(true)
+			b.WriteString(style.Render(label))
+		} else {
+			style := lipgloss.NewStyle().Foreground(zstyle.Overlay1)
+			b.WriteString(style.Render(label))
+		}
+		if i < filterCount-1 {
+			sep := lipgloss.NewStyle().Foreground(zstyle.Surface2).Render(" | ")
+			b.WriteString(sep)
+		}
+	}
+	b.WriteString("\n")
+
+	// search bar
+	if m.searching {
+		b.WriteString("  " + m.search.View() + "\n")
+	} else if m.search.Value() != "" {
+		muted := zstyle.MutedText.Render(fmt.Sprintf("  search: %s", m.search.Value()))
+		b.WriteString(muted + "\n")
+	}
+
+	b.WriteString("\n")
+
+	if len(m.secrets) == 0 {
+		msg := zstyle.MutedText.Render("  no secrets found")
+		b.WriteString(msg + "\n")
+	} else {
+		// calculate visible area (rough: height minus header/footer/filter/padding)
+		visibleHeight := m.height - 10
+		if visibleHeight < 3 {
+			visibleHeight = 3
+		}
+
+		// scroll window
+		start := 0
+		if m.cursor >= visibleHeight {
+			start = m.cursor - visibleHeight + 1
+		}
+		end := start + visibleHeight
+		if end > len(m.secrets) {
+			end = len(m.secrets)
+		}
+
+		for i := start; i < end; i++ {
+			s := m.secrets[i]
+			cursor := "  "
+			nameStyle := lipgloss.NewStyle().Foreground(zstyle.Text)
+			if i == m.cursor {
+				cursor = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent).Render("▸ ")
+				nameStyle = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent).Bold(true)
+			}
+
+			name := nameStyle.Render(s.Name)
+			badge := typeBadge(s.Type)
+			tags := ""
+			if len(s.Tags) > 0 {
+				tags = zstyle.MutedText.Render(" [" + strings.Join(s.Tags, ", ") + "]")
+			}
+
+			b.WriteString(fmt.Sprintf("  %s%s %s%s\n", cursor, name, badge, tags))
+		}
+	}
+
+	// delete confirmation
+	if m.confirmDelete && m.cursor < len(m.secrets) {
+		s := m.secrets[m.cursor]
+		warn := lipgloss.NewStyle().Foreground(zstyle.Warning)
+		b.WriteString("\n")
+		b.WriteString(warn.Render(fmt.Sprintf("  Delete '%s'? (y/n)", s.Name)))
+		b.WriteString("\n")
+	}
+
+	// status message
+	if m.status != "" {
+		b.WriteString("\n")
+		b.WriteString(zstyle.StatusOK.Render("  " + m.status))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// typeBadge returns a styled badge for the secret type.
+func typeBadge(t secret.Type) string {
+	var label string
+	var color lipgloss.Color
+	switch t {
+	case secret.TypePassword:
+		label = "pw"
+		color = zstyle.Blue
+	case secret.TypeAPIKey:
+		label = "api"
+		color = zstyle.Peach
+	case secret.TypeSSHKey:
+		label = "ssh"
+		color = zstyle.Green
+	case secret.TypeNote:
+		label = "note"
+		color = zstyle.Yellow
+	default:
+		label = string(t)
+		color = zstyle.Overlay1
+	}
+	return lipgloss.NewStyle().Foreground(color).Render("[" + label + "]")
+}

--- a/internal/tui/secret_list_test.go
+++ b/internal/tui/secret_list_test.go
@@ -1,0 +1,253 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zarlcorp/zvault/internal/secret"
+)
+
+func TestSecretListViewEmpty(t *testing.T) {
+	m := newSecretList()
+	view := m.View()
+	if !strings.Contains(view, "no secrets found") {
+		t.Error("empty list should show 'no secrets found'")
+	}
+}
+
+func TestSecretListViewShowsFilterTabs(t *testing.T) {
+	m := newSecretList()
+	view := m.View()
+	for _, label := range []string{"All", "Password", "API Key", "SSH Key", "Note"} {
+		if !strings.Contains(view, label) {
+			t.Errorf("list should show filter tab %q", label)
+		}
+	}
+}
+
+func TestSecretListEscNavigatesBack(t *testing.T) {
+	m := newSecretList()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc should produce a navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewMenu {
+		t.Fatalf("nav view = %d, want viewMenu", nav.view)
+	}
+}
+
+func TestSecretListCursorNavigation(t *testing.T) {
+	m := newSecretList()
+	m.secrets = []secret.Secret{
+		{ID: "1", Name: "First", Type: secret.TypePassword},
+		{ID: "2", Name: "Second", Type: secret.TypeAPIKey},
+		{ID: "3", Name: "Third", Type: secret.TypeNote},
+	}
+	m.cursor = 0
+
+	// move down
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1", m.cursor)
+	}
+
+	// move down again
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 2 {
+		t.Fatalf("cursor = %d, want 2", m.cursor)
+	}
+
+	// can't go past end
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 2 {
+		t.Fatalf("cursor = %d, want 2 (bounded)", m.cursor)
+	}
+
+	// move up
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1", m.cursor)
+	}
+}
+
+func TestSecretListEnterNavigatesToDetail(t *testing.T) {
+	m := newSecretList()
+	m.secrets = []secret.Secret{
+		{ID: "abc123", Name: "Test", Type: secret.TypePassword},
+	}
+	m.cursor = 0
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter should produce a navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewSecretDetail {
+		t.Fatalf("nav view = %d, want viewSecretDetail", nav.view)
+	}
+	if nav.data != "abc123" {
+		t.Fatalf("nav data = %v, want 'abc123'", nav.data)
+	}
+}
+
+func TestSecretListSearchMode(t *testing.T) {
+	m := newSecretList()
+	if m.searching {
+		t.Fatal("should not start in search mode")
+	}
+
+	// enter search mode
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	if !m.searching {
+		t.Fatal("should be in search mode after /")
+	}
+
+	// esc exits search mode
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if m.searching {
+		t.Fatal("should exit search mode on esc")
+	}
+}
+
+func TestSecretListFilterCycle(t *testing.T) {
+	m := newSecretList()
+	if m.filter != filterAll {
+		t.Fatalf("initial filter = %d, want filterAll", m.filter)
+	}
+
+	tabKey := tea.KeyMsg{Type: tea.KeyTab}
+
+	// tab cycles filter
+	m, _ = m.Update(tabKey)
+	if m.filter != filterPassword {
+		t.Fatalf("filter = %d, want filterPassword", m.filter)
+	}
+
+	m, _ = m.Update(tabKey)
+	if m.filter != filterAPIKey {
+		t.Fatalf("filter = %d, want filterAPIKey", m.filter)
+	}
+
+	m, _ = m.Update(tabKey)
+	if m.filter != filterSSHKey {
+		t.Fatalf("filter = %d, want filterSSHKey", m.filter)
+	}
+
+	m, _ = m.Update(tabKey)
+	if m.filter != filterNote {
+		t.Fatalf("filter = %d, want filterNote", m.filter)
+	}
+
+	// wraps back to all
+	m, _ = m.Update(tabKey)
+	if m.filter != filterAll {
+		t.Fatalf("filter = %d, want filterAll (wrapped)", m.filter)
+	}
+}
+
+func TestSecretListNewNavigatesToForm(t *testing.T) {
+	m := newSecretList()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd == nil {
+		t.Fatal("n should produce a navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewSecretForm {
+		t.Fatalf("nav view = %d, want viewSecretForm", nav.view)
+	}
+	if nav.data != nil {
+		t.Fatalf("nav data should be nil for new secret, got %v", nav.data)
+	}
+}
+
+func TestSecretListDeleteConfirmation(t *testing.T) {
+	m := newSecretList()
+	m.secrets = []secret.Secret{
+		{ID: "1", Name: "MySecret", Type: secret.TypePassword},
+	}
+	m.cursor = 0
+
+	// press d to trigger delete confirm
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if !m.confirmDelete {
+		t.Fatal("d should trigger delete confirmation")
+	}
+
+	// pressing n cancels
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.confirmDelete {
+		t.Fatal("n should cancel delete confirmation")
+	}
+}
+
+func TestSecretListDeleteConfirmView(t *testing.T) {
+	m := newSecretList()
+	m.secrets = []secret.Secret{
+		{ID: "1", Name: "MySecret", Type: secret.TypePassword},
+	}
+	m.cursor = 0
+	m.confirmDelete = true
+
+	view := m.View()
+	if !strings.Contains(view, "Delete 'MySecret'? (y/n)") {
+		t.Error("delete confirmation should show secret name")
+	}
+}
+
+func TestSecretListViewShowsSecrets(t *testing.T) {
+	m := newSecretList()
+	m.secrets = []secret.Secret{
+		{ID: "1", Name: "GitHub", Type: secret.TypePassword, Tags: []string{"dev"}},
+		{ID: "2", Name: "AWS Key", Type: secret.TypeAPIKey},
+	}
+	m.height = 30 // enough height for all items
+
+	view := m.View()
+	if !strings.Contains(view, "GitHub") {
+		t.Error("list should show secret name 'GitHub'")
+	}
+	if !strings.Contains(view, "AWS Key") {
+		t.Error("list should show secret name 'AWS Key'")
+	}
+	if !strings.Contains(view, "[pw]") {
+		t.Error("list should show password badge")
+	}
+	if !strings.Contains(view, "[api]") {
+		t.Error("list should show api badge")
+	}
+	if !strings.Contains(view, "dev") {
+		t.Error("list should show tags")
+	}
+}
+
+func TestTypeBadge(t *testing.T) {
+	tests := []struct {
+		typ  secret.Type
+		want string
+	}{
+		{secret.TypePassword, "pw"},
+		{secret.TypeAPIKey, "api"},
+		{secret.TypeSSHKey, "ssh"},
+		{secret.TypeNote, "note"},
+	}
+	for _, tt := range tests {
+		badge := typeBadge(tt.typ)
+		if !strings.Contains(badge, tt.want) {
+			t.Errorf("typeBadge(%s) = %q, should contain %q", tt.typ, badge, tt.want)
+		}
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -68,14 +68,28 @@ func TestCtrlCQuitsFromMenu(t *testing.T) {
 	}
 }
 
-func TestQQuitsFromPlaceholder(t *testing.T) {
-	views := []viewID{viewSecretList, viewSecretDetail, viewSecretForm, viewTaskList, viewTaskDetail, viewTaskForm}
-	for _, v := range views {
+func TestQQuitsFromNonInputViews(t *testing.T) {
+	// secret list (not searching) and secret detail quit on q
+	quitViews := []viewID{viewSecretList, viewSecretDetail, viewTaskList, viewTaskDetail, viewTaskForm}
+	for _, v := range quitViews {
 		m := newTestModel()
 		m.view = v
 		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 		if cmd == nil {
 			t.Fatalf("q should return quit command from view %d", v)
+		}
+	}
+}
+
+func TestQDoesNotQuitFromSecretForm(t *testing.T) {
+	// secret form has text input active, q should not quit
+	m := newTestModel()
+	m.view = viewSecretForm
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(tea.QuitMsg); ok {
+			t.Fatal("q should not quit from secret form (text input active)")
 		}
 	}
 }


### PR DESCRIPTION
Closes #17

Spec: .manager/specs/048-zvault-tui-secrets.md

## Changes
- Secret list view: scrollable list with type filter tabs, search mode, type badges, tags
- Secret detail view: all fields displayed, sensitive fields masked, toggle with `s`, copy to clipboard with `c` (auto-clear 10s)
- Secret form: create/edit with type selector, dynamic fields per type, masked password inputs, tab navigation
- Clipboard utility: copy + auto-clear after 10s via tea.Tick
- Integrated into tui.go: replaced placeholder models, updated dispatch, size propagation, vault propagation
- Updated footer keybindings for all secret views
- 87 tests passing across all packages