### PR TITLE
049: add TUI task views with list, detail, form, and date parsing

### DIFF
--- a/internal/tui/dates.go
+++ b/internal/tui/dates.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// nowFunc allows tests to override the current time.
+var nowFunc = time.Now
+
+// formatRelativeDate returns a human-readable relative date string.
+// Future: "tomorrow", "in 3 days", "next week", "Mar 1"
+// Past: "yesterday", "overdue by 2 days"
+// Today: "today"
+func formatRelativeDate(t time.Time) string {
+	now := nowFunc()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	target := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	days := int(target.Sub(today).Hours() / 24)
+
+	switch {
+	case days == 0:
+		return "today"
+	case days == 1:
+		return "tomorrow"
+	case days == -1:
+		return "yesterday"
+	case days > 1 && days <= 7:
+		return fmt.Sprintf("in %d days", days)
+	case days > 7 && days <= 14:
+		return "next week"
+	case days > 14:
+		return t.Format("Jan 2")
+	case days < -1:
+		return fmt.Sprintf("overdue by %d days", -days)
+	}
+	return t.Format("Jan 2")
+}
+
+// formatDueDate returns a display string for a due date in the list view.
+// Returns empty string for nil.
+func formatDueDate(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return formatRelativeDate(*t)
+}
+
+// isOverdue returns true if the date is before today.
+func isOverdue(t *time.Time) bool {
+	if t == nil {
+		return false
+	}
+	now := nowFunc()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	target := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	return target.Before(today)
+}
+
+// parseRelativeDate parses a date string that can be:
+// - YYYY-MM-DD: absolute date
+// - tomorrow: next day
+// - +3d: 3 days from now
+// - +1w: 1 week from now
+// - next week: 7 days from now
+// - today: current day
+// Returns nil time pointer and error for empty/invalid input.
+func parseRelativeDate(s string) (*time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+
+	now := nowFunc()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	lower := strings.ToLower(s)
+
+	switch lower {
+	case "today":
+		return &today, nil
+	case "tomorrow":
+		t := today.AddDate(0, 0, 1)
+		return &t, nil
+	case "next week":
+		t := today.AddDate(0, 0, 7)
+		return &t, nil
+	}
+
+	// +Nd format (days)
+	if strings.HasPrefix(lower, "+") && strings.HasSuffix(lower, "d") {
+		numStr := lower[1 : len(lower)-1]
+		n, err := strconv.Atoi(numStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid day offset: %s", s)
+		}
+		t := today.AddDate(0, 0, n)
+		return &t, nil
+	}
+
+	// +Nw format (weeks)
+	if strings.HasPrefix(lower, "+") && strings.HasSuffix(lower, "w") {
+		numStr := lower[1 : len(lower)-1]
+		n, err := strconv.Atoi(numStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid week offset: %s", s)
+		}
+		t := today.AddDate(0, 0, n*7)
+		return &t, nil
+	}
+
+	// YYYY-MM-DD
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid date format: %s (use YYYY-MM-DD, tomorrow, +3d, next week)", s)
+	}
+	return &t, nil
+}
+
+// formatDateForEdit returns a YYYY-MM-DD string for editing, or empty for nil.
+func formatDateForEdit(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}

--- a/internal/tui/dates_test.go
+++ b/internal/tui/dates_test.go
@@ -1,0 +1,142 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+func fixedTime(year int, month time.Month, day int) func() time.Time {
+	return func() time.Time {
+		return time.Date(year, month, day, 12, 0, 0, 0, time.Local)
+	}
+}
+
+func TestFormatRelativeDate(t *testing.T) {
+	orig := nowFunc
+	defer func() { nowFunc = orig }()
+	nowFunc = fixedTime(2026, time.February, 18)
+
+	tests := []struct {
+		name string
+		date time.Time
+		want string
+	}{
+		{"today", time.Date(2026, 2, 18, 0, 0, 0, 0, time.Local), "today"},
+		{"tomorrow", time.Date(2026, 2, 19, 0, 0, 0, 0, time.Local), "tomorrow"},
+		{"yesterday", time.Date(2026, 2, 17, 0, 0, 0, 0, time.Local), "yesterday"},
+		{"in 3 days", time.Date(2026, 2, 21, 0, 0, 0, 0, time.Local), "in 3 days"},
+		{"in 7 days", time.Date(2026, 2, 25, 0, 0, 0, 0, time.Local), "in 7 days"},
+		{"next week", time.Date(2026, 2, 28, 0, 0, 0, 0, time.Local), "next week"},
+		{"far future", time.Date(2026, 4, 15, 0, 0, 0, 0, time.Local), "Apr 15"},
+		{"overdue by 2", time.Date(2026, 2, 16, 0, 0, 0, 0, time.Local), "overdue by 2 days"},
+		{"overdue by 5", time.Date(2026, 2, 13, 0, 0, 0, 0, time.Local), "overdue by 5 days"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatRelativeDate(tt.date)
+			if got != tt.want {
+				t.Errorf("formatRelativeDate(%v) = %q, want %q", tt.date, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatDueDateNil(t *testing.T) {
+	got := formatDueDate(nil)
+	if got != "" {
+		t.Errorf("formatDueDate(nil) = %q, want empty", got)
+	}
+}
+
+func TestIsOverdue(t *testing.T) {
+	orig := nowFunc
+	defer func() { nowFunc = orig }()
+	nowFunc = fixedTime(2026, time.February, 18)
+
+	past := time.Date(2026, 2, 17, 0, 0, 0, 0, time.Local)
+	today := time.Date(2026, 2, 18, 0, 0, 0, 0, time.Local)
+	future := time.Date(2026, 2, 19, 0, 0, 0, 0, time.Local)
+
+	if !isOverdue(&past) {
+		t.Error("past date should be overdue")
+	}
+	if isOverdue(&today) {
+		t.Error("today should not be overdue")
+	}
+	if isOverdue(&future) {
+		t.Error("future date should not be overdue")
+	}
+	if isOverdue(nil) {
+		t.Error("nil should not be overdue")
+	}
+}
+
+func TestParseRelativeDate(t *testing.T) {
+	orig := nowFunc
+	defer func() { nowFunc = orig }()
+	nowFunc = fixedTime(2026, time.February, 18)
+
+	today := time.Date(2026, 2, 18, 0, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name    string
+		input   string
+		want    *time.Time
+		wantErr bool
+	}{
+		{"empty", "", nil, false},
+		{"today", "today", ptr(today), false},
+		{"tomorrow", "tomorrow", ptr(today.AddDate(0, 0, 1)), false},
+		{"next week", "next week", ptr(today.AddDate(0, 0, 7)), false},
+		{"plus 3d", "+3d", ptr(today.AddDate(0, 0, 3)), false},
+		{"plus 1w", "+1w", ptr(today.AddDate(0, 0, 7)), false},
+		{"plus 2w", "+2w", ptr(today.AddDate(0, 0, 14)), false},
+		{"absolute", "2026-03-01", ptr(time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)), false},
+		{"case insensitive", "Tomorrow", ptr(today.AddDate(0, 0, 1)), false},
+		{"case insensitive next", "Next Week", ptr(today.AddDate(0, 0, 7)), false},
+		{"invalid", "garbage", nil, true},
+		{"bad plus", "+xd", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRelativeDate(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseRelativeDate(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.want == nil && got != nil {
+				t.Errorf("parseRelativeDate(%q) = %v, want nil", tt.input, got)
+				return
+			}
+			if tt.want != nil {
+				if got == nil {
+					t.Errorf("parseRelativeDate(%q) = nil, want %v", tt.input, tt.want)
+					return
+				}
+				if !got.Equal(*tt.want) {
+					t.Errorf("parseRelativeDate(%q) = %v, want %v", tt.input, *got, *tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatDateForEdit(t *testing.T) {
+	d := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	got := formatDateForEdit(&d)
+	if got != "2026-03-15" {
+		t.Errorf("formatDateForEdit = %q, want 2026-03-15", got)
+	}
+	if formatDateForEdit(nil) != "" {
+		t.Error("formatDateForEdit(nil) should be empty")
+	}
+}
+
+func ptr(t time.Time) *time.Time {
+	return &t
+}

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -55,7 +55,7 @@ func helpFor(id viewID) []helpEntry {
 			{"enter", "select"},
 			{"q", "quit"},
 		}
-	case viewSecretList, viewTaskList:
+	case viewSecretList:
 		return []helpEntry{
 			{"↑/k", "up"},
 			{"↓/j", "down"},
@@ -63,15 +63,40 @@ func helpFor(id viewID) []helpEntry {
 			{"esc", "back"},
 			{"q", "quit"},
 		}
-	case viewSecretDetail, viewTaskDetail:
+	case viewTaskList:
+		return []helpEntry{
+			{"↑/k", "up"},
+			{"↓/j", "down"},
+			{"enter", "detail"},
+			{"n", "new"},
+			{"space", "toggle done"},
+			{"d", "delete"},
+			{"x", "clear done"},
+			{"tab", "filter"},
+			{"esc", "back"},
+		}
+	case viewSecretDetail:
 		return []helpEntry{
 			{"esc", "back"},
 			{"q", "quit"},
 		}
-	case viewSecretForm, viewTaskForm:
+	case viewTaskDetail:
+		return []helpEntry{
+			{"e", "edit"},
+			{"space", "toggle done"},
+			{"d", "delete"},
+			{"esc", "back"},
+		}
+	case viewSecretForm:
 		return []helpEntry{
 			{"tab", "next field"},
 			{"enter", "save"},
+			{"esc", "cancel"},
+		}
+	case viewTaskForm:
+		return []helpEntry{
+			{"tab", "next field"},
+			{"ctrl+s", "save"},
 			{"esc", "cancel"},
 		}
 	default:

--- a/internal/tui/task_detail.go
+++ b/internal/tui/task_detail.go
@@ -1,0 +1,223 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/zarlcorp/core/pkg/zstyle"
+	"github.com/zarlcorp/zvault/internal/task"
+	"github.com/zarlcorp/zvault/internal/vault"
+)
+
+// taskDetailModel shows full details for a single task.
+type taskDetailModel struct {
+	vault   *vault.Vault
+	task    task.Task
+	loaded  bool
+	confirm confirmKind
+	width   int
+	height  int
+}
+
+func newTaskDetailModel(v *vault.Vault) taskDetailModel {
+	return taskDetailModel{vault: v}
+}
+
+func (m *taskDetailModel) loadTask(id string) {
+	if m.vault == nil {
+		return
+	}
+	t, err := m.vault.Tasks().Get(id)
+	if err != nil {
+		m.loaded = false
+		return
+	}
+	m.task = t
+	m.loaded = true
+	m.confirm = confirmNone
+}
+
+func (m taskDetailModel) Update(msg tea.Msg) (taskDetailModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case navigateMsg:
+		if msg.view == viewTaskDetail {
+			if id, ok := msg.data.(string); ok {
+				m.loadTask(id)
+			}
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		// handle confirmation first
+		if m.confirm != confirmNone {
+			return m.handleConfirm(msg)
+		}
+
+		switch {
+		case key.Matches(msg, zstyle.KeyBack):
+			return m, func() tea.Msg { return navigateMsg{view: viewTaskList} }
+
+		case msg.String() == "e":
+			if m.loaded {
+				t := m.task
+				return m, func() tea.Msg { return navigateMsg{view: viewTaskForm, data: t} }
+			}
+
+		case msg.String() == " ":
+			if m.loaded {
+				return m.toggleDone()
+			}
+
+		case msg.String() == "d":
+			if m.loaded {
+				m.confirm = confirmDelete
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m taskDetailModel) handleConfirm(msg tea.KeyMsg) (taskDetailModel, tea.Cmd) {
+	switch msg.String() {
+	case "y":
+		if m.confirm == confirmDelete {
+			m.confirm = confirmNone
+			return m.deleteTask()
+		}
+	case "n", "esc":
+		m.confirm = confirmNone
+	}
+	return m, nil
+}
+
+func (m taskDetailModel) toggleDone() (taskDetailModel, tea.Cmd) {
+	if m.vault == nil {
+		return m, nil
+	}
+
+	m.task.Done = !m.task.Done
+	if m.task.Done {
+		now := nowFunc()
+		m.task.CompletedAt = &now
+	} else {
+		m.task.CompletedAt = nil
+	}
+
+	if err := m.vault.Tasks().Update(m.task); err != nil {
+		return m, func() tea.Msg { return errMsg{err: err} }
+	}
+	return m, nil
+}
+
+func (m taskDetailModel) deleteTask() (taskDetailModel, tea.Cmd) {
+	if m.vault == nil {
+		return m, nil
+	}
+
+	if err := m.vault.Tasks().Delete(m.task.ID); err != nil {
+		return m, func() tea.Msg { return errMsg{err: err} }
+	}
+	return m, func() tea.Msg { return navigateMsg{view: viewTaskList} }
+}
+
+var (
+	detailLabelStyle = lipgloss.NewStyle().Foreground(zstyle.Overlay1).Width(12)
+	detailValueStyle = lipgloss.NewStyle().Foreground(zstyle.Text)
+)
+
+func (m taskDetailModel) View() string {
+	if !m.loaded {
+		return fmt.Sprintf("\n  %s\n", zstyle.MutedText.Render("no task selected"))
+	}
+
+	var b strings.Builder
+	b.WriteString("\n")
+
+	// title
+	titleStyle := lipgloss.NewStyle().Foreground(zstyle.Text).Bold(true)
+	b.WriteString(fmt.Sprintf("  %s\n\n", titleStyle.Render(m.task.Title)))
+
+	// status
+	status := "Pending"
+	statusStyle := detailValueStyle.Foreground(zstyle.Yellow)
+	if m.task.Done {
+		status = "Done"
+		statusStyle = detailValueStyle.Foreground(zstyle.Green)
+	}
+	b.WriteString(fmt.Sprintf("  %s%s\n", detailLabelStyle.Render("Status"), statusStyle.Render(status)))
+
+	// priority
+	pri := formatPriority(m.task.Priority)
+	priStyle := priorityStyle(m.task.Priority)
+	b.WriteString(fmt.Sprintf("  %s%s\n", detailLabelStyle.Render("Priority"), priStyle.Render(pri)))
+
+	// due date
+	if m.task.DueDate != nil {
+		dueStr := formatRelativeDate(*m.task.DueDate)
+		dateStr := m.task.DueDate.Format("2006-01-02")
+		display := fmt.Sprintf("%s (%s)", dueStr, dateStr)
+		dueStyle := detailValueStyle
+		if !m.task.Done && isOverdue(m.task.DueDate) {
+			dueStyle = detailValueStyle.Foreground(zstyle.Red)
+		}
+		b.WriteString(fmt.Sprintf("  %s%s\n", detailLabelStyle.Render("Due"), dueStyle.Render(display)))
+	}
+
+	// tags
+	if len(m.task.Tags) > 0 {
+		var tagStrs []string
+		for _, tag := range m.task.Tags {
+			tagStrs = append(tagStrs, "#"+tag)
+		}
+		b.WriteString(fmt.Sprintf("  %s%s\n",
+			detailLabelStyle.Render("Tags"),
+			taskTagStyle.Render(strings.Join(tagStrs, " "))))
+	}
+
+	// created
+	b.WriteString(fmt.Sprintf("  %s%s\n",
+		detailLabelStyle.Render("Created"),
+		zstyle.MutedText.Render(m.task.CreatedAt.Format("2006-01-02 15:04"))))
+
+	// completed
+	if m.task.CompletedAt != nil {
+		b.WriteString(fmt.Sprintf("  %s%s\n",
+			detailLabelStyle.Render("Completed"),
+			zstyle.MutedText.Render(m.task.CompletedAt.Format("2006-01-02 15:04"))))
+	}
+
+	// confirmation prompt
+	if m.confirm == confirmDelete {
+		b.WriteString(fmt.Sprintf("\n  %s\n",
+			zstyle.StatusWarn.Render(fmt.Sprintf("Delete \"%s\"? (y/n)", m.task.Title))))
+	}
+
+	return b.String()
+}
+
+func formatPriority(p task.Priority) string {
+	switch p {
+	case task.PriorityHigh:
+		return "High"
+	case task.PriorityMedium:
+		return "Medium"
+	case task.PriorityLow:
+		return "Low"
+	default:
+		return "None"
+	}
+}
+
+func priorityStyle(p task.Priority) lipgloss.Style {
+	switch p {
+	case task.PriorityHigh:
+		return detailValueStyle.Foreground(zstyle.Red)
+	case task.PriorityMedium:
+		return detailValueStyle.Foreground(zstyle.Yellow)
+	default:
+		return detailValueStyle
+	}
+}

--- a/internal/tui/task_detail_test.go
+++ b/internal/tui/task_detail_test.go
@@ -1,0 +1,223 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zarlcorp/zvault/internal/task"
+)
+
+func TestTaskDetailNotLoaded(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskDetailModel(v)
+	view := m.View()
+	if !strings.Contains(view, "no task selected") {
+		t.Error("unloaded detail should show 'no task selected'")
+	}
+}
+
+func TestTaskDetailShowsTask(t *testing.T) {
+	orig := nowFunc
+	defer func() { nowFunc = orig }()
+	nowFunc = fixedTime(2026, time.February, 18)
+
+	v := openTestVault(t)
+	due := time.Date(2026, 2, 20, 0, 0, 0, 0, time.Local)
+	tk := addTask(t, v, "Review PR", withPriority(task.PriorityHigh), withDue(due), withTags("work"))
+
+	m := newTaskDetailModel(v)
+	m.loadTask(tk.ID)
+
+	view := m.View()
+	if !strings.Contains(view, "Review PR") {
+		t.Error("should show title")
+	}
+	if !strings.Contains(view, "High") {
+		t.Error("should show priority")
+	}
+	if !strings.Contains(view, "in 2 days") {
+		t.Error("should show relative due date")
+	}
+	if !strings.Contains(view, "#work") {
+		t.Error("should show tags")
+	}
+	if !strings.Contains(view, "Pending") {
+		t.Error("should show status")
+	}
+}
+
+func TestTaskDetailShowsDoneStatus(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Finished task", withDone())
+
+	m := newTaskDetailModel(v)
+	m.loadTask(tk.ID)
+
+	view := m.View()
+	if !strings.Contains(view, "Done") {
+		t.Error("should show Done status")
+	}
+	if !strings.Contains(view, "Completed") {
+		t.Error("should show Completed timestamp")
+	}
+}
+
+func TestTaskDetailEscGoesBack(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskDetailModel(v)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc should produce navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskList {
+		t.Fatalf("nav = %d, want viewTaskList", nav.view)
+	}
+}
+
+func TestTaskDetailEditNavigates(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Edit me")
+
+	m := newTaskDetailModel(v)
+	m.loadTask(tk.ID)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd == nil {
+		t.Fatal("e should produce navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskForm {
+		t.Fatalf("nav = %d, want viewTaskForm", nav.view)
+	}
+	taskData, ok := nav.data.(task.Task)
+	if !ok {
+		t.Fatalf("expected task.Task data, got %T", nav.data)
+	}
+	if taskData.Title != "Edit me" {
+		t.Fatalf("task title = %q, want 'Edit me'", taskData.Title)
+	}
+}
+
+func TestTaskDetailToggleDone(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Toggle me")
+
+	m := newTaskDetailModel(v)
+	m.loadTask(tk.ID)
+
+	// toggle to done
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if !m.task.Done {
+		t.Error("task should be done after toggle")
+	}
+
+	// toggle back
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if m.task.Done {
+		t.Error("task should be pending after second toggle")
+	}
+}
+
+func TestTaskDetailDeleteConfirm(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Delete me")
+
+	m := newTaskDetailModel(v)
+	m.loadTask(tk.ID)
+
+	// press d
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if m.confirm != confirmDelete {
+		t.Fatal("should be in delete confirmation")
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "Delete") {
+		t.Error("should show delete prompt")
+	}
+
+	// press y to confirm
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	_ = m
+
+	// should navigate back to list
+	if cmd == nil {
+		t.Fatal("should navigate after delete")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskList {
+		t.Fatalf("nav = %d, want viewTaskList", nav.view)
+	}
+
+	// task should be gone
+	_, err := v.Tasks().Get(tk.ID)
+	if err == nil {
+		t.Fatal("task should be deleted")
+	}
+}
+
+func TestTaskDetailDeleteCancel(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Keep me")
+
+	m := newTaskDetailModel(v)
+	m.loadTask(tk.ID)
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.confirm != confirmNone {
+		t.Fatal("should cancel confirmation")
+	}
+
+	_, err := v.Tasks().Get(tk.ID)
+	if err != nil {
+		t.Fatal("task should still exist")
+	}
+}
+
+func TestTaskDetailOverdueDateRed(t *testing.T) {
+	orig := nowFunc
+	defer func() { nowFunc = orig }()
+	nowFunc = fixedTime(2026, time.February, 18)
+
+	v := openTestVault(t)
+	past := time.Date(2026, 2, 15, 0, 0, 0, 0, time.Local)
+	tk := addTask(t, v, "Overdue task", withDue(past))
+
+	m := newTaskDetailModel(v)
+	m.loadTask(tk.ID)
+
+	view := m.View()
+	if !strings.Contains(view, "overdue") {
+		t.Error("should show overdue text")
+	}
+}
+
+func TestTaskDetailNavigateMsg(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Nav task")
+
+	m := newTaskDetailModel(v)
+	m, _ = m.Update(navigateMsg{view: viewTaskDetail, data: tk.ID})
+	if !m.loaded {
+		t.Fatal("should be loaded after navigateMsg")
+	}
+	if m.task.Title != "Nav task" {
+		t.Fatalf("title = %q, want 'Nav task'", m.task.Title)
+	}
+}

--- a/internal/tui/task_form.go
+++ b/internal/tui/task_form.go
@@ -1,0 +1,343 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/zarlcorp/core/pkg/zstyle"
+	"github.com/zarlcorp/zvault/internal/task"
+	"github.com/zarlcorp/zvault/internal/vault"
+)
+
+// formField identifies which form field is focused.
+type formField int
+
+const (
+	fieldTitle formField = iota
+	fieldPriority
+	fieldDue
+	fieldTags
+	formFieldCount // sentinel
+)
+
+// taskFormModel handles create and edit forms for tasks.
+type taskFormModel struct {
+	vault    *vault.Vault
+	editing  *task.Task // nil = create mode, non-nil = edit mode
+	title    textinput.Model
+	due      textinput.Model
+	tags     textinput.Model
+	priority task.Priority
+	focused  formField
+	err      string
+	width    int
+	height   int
+}
+
+var priorities = []task.Priority{
+	task.PriorityNone,
+	task.PriorityLow,
+	task.PriorityMedium,
+	task.PriorityHigh,
+}
+
+func newTaskFormModel(v *vault.Vault) taskFormModel {
+	titleInput := textinput.New()
+	titleInput.Placeholder = "task title"
+	titleInput.Focus()
+	titleInput.PromptStyle = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent)
+	titleInput.TextStyle = lipgloss.NewStyle().Foreground(zstyle.Text)
+
+	dueInput := textinput.New()
+	dueInput.Placeholder = "YYYY-MM-DD, tomorrow, +3d, next week"
+	dueInput.PromptStyle = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent)
+	dueInput.TextStyle = lipgloss.NewStyle().Foreground(zstyle.Text)
+
+	tagsInput := textinput.New()
+	tagsInput.Placeholder = "comma-separated tags"
+	tagsInput.PromptStyle = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent)
+	tagsInput.TextStyle = lipgloss.NewStyle().Foreground(zstyle.Text)
+
+	return taskFormModel{
+		vault:   v,
+		title:   titleInput,
+		due:     dueInput,
+		tags:    tagsInput,
+		focused: fieldTitle,
+	}
+}
+
+func (m *taskFormModel) reset() {
+	m.editing = nil
+	m.title.SetValue("")
+	m.due.SetValue("")
+	m.tags.SetValue("")
+	m.priority = task.PriorityNone
+	m.focused = fieldTitle
+	m.err = ""
+	m.title.Focus()
+	m.due.Blur()
+	m.tags.Blur()
+}
+
+func (m *taskFormModel) loadTask(t task.Task) {
+	m.editing = &t
+	m.title.SetValue(t.Title)
+	m.priority = t.Priority
+	m.due.SetValue(formatDateForEdit(t.DueDate))
+	if len(t.Tags) > 0 {
+		m.tags.SetValue(strings.Join(t.Tags, ", "))
+	} else {
+		m.tags.SetValue("")
+	}
+	m.focused = fieldTitle
+	m.err = ""
+	m.title.Focus()
+	m.due.Blur()
+	m.tags.Blur()
+}
+
+func (m taskFormModel) Update(msg tea.Msg) (taskFormModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case navigateMsg:
+		if msg.view == viewTaskForm {
+			if t, ok := msg.data.(task.Task); ok {
+				m.loadTask(t)
+			} else {
+				m.reset()
+			}
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		m.err = ""
+
+		switch {
+		case key.Matches(msg, zstyle.KeyBack):
+			return m, func() tea.Msg { return navigateMsg{view: viewTaskList} }
+
+		case msg.Type == tea.KeyCtrlS:
+			return m.save()
+
+		case key.Matches(msg, zstyle.KeyTab):
+			return m.nextField(), nil
+
+		case msg.Type == tea.KeyShiftTab:
+			return m.prevField(), nil
+
+		case key.Matches(msg, zstyle.KeyEnter):
+			// enter on priority field cycles priority
+			if m.focused == fieldPriority {
+				m.cyclePriority()
+				return m, nil
+			}
+			// enter on last field saves
+			if m.focused == fieldTags {
+				return m.save()
+			}
+			// enter on other fields moves to next
+			return m.nextField(), nil
+
+		case msg.String() == " " && m.focused == fieldPriority:
+			m.cyclePriority()
+			return m, nil
+		}
+	}
+
+	return m.updateInputs(msg)
+}
+
+func (m *taskFormModel) cyclePriority() {
+	for i, p := range priorities {
+		if p == m.priority {
+			m.priority = priorities[(i+1)%len(priorities)]
+			return
+		}
+	}
+	m.priority = priorities[0]
+}
+
+func (m taskFormModel) nextField() taskFormModel {
+	m.blurAll()
+	m.focused = (m.focused + 1) % formFieldCount
+	m.focusCurrent()
+	return m
+}
+
+func (m taskFormModel) prevField() taskFormModel {
+	m.blurAll()
+	if m.focused == 0 {
+		m.focused = formFieldCount - 1
+	} else {
+		m.focused--
+	}
+	m.focusCurrent()
+	return m
+}
+
+func (m *taskFormModel) blurAll() {
+	m.title.Blur()
+	m.due.Blur()
+	m.tags.Blur()
+}
+
+func (m *taskFormModel) focusCurrent() {
+	switch m.focused {
+	case fieldTitle:
+		m.title.Focus()
+	case fieldDue:
+		m.due.Focus()
+	case fieldTags:
+		m.tags.Focus()
+	}
+}
+
+func (m taskFormModel) updateInputs(msg tea.Msg) (taskFormModel, tea.Cmd) {
+	var cmd tea.Cmd
+	switch m.focused {
+	case fieldTitle:
+		m.title, cmd = m.title.Update(msg)
+	case fieldDue:
+		m.due, cmd = m.due.Update(msg)
+	case fieldTags:
+		m.tags, cmd = m.tags.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m taskFormModel) save() (taskFormModel, tea.Cmd) {
+	title := strings.TrimSpace(m.title.Value())
+	if title == "" {
+		m.err = "title is required"
+		return m, nil
+	}
+
+	// parse due date
+	dueDate, err := parseRelativeDate(m.due.Value())
+	if err != nil {
+		m.err = err.Error()
+		return m, nil
+	}
+
+	// parse tags
+	var tags []string
+	if raw := strings.TrimSpace(m.tags.Value()); raw != "" {
+		for _, t := range strings.Split(raw, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				tags = append(tags, t)
+			}
+		}
+	}
+
+	if m.vault == nil {
+		m.err = "vault not available"
+		return m, nil
+	}
+
+	if m.editing != nil {
+		// update existing
+		m.editing.Title = title
+		m.editing.Priority = m.priority
+		m.editing.DueDate = dueDate
+		m.editing.Tags = tags
+		if err := m.vault.Tasks().Update(*m.editing); err != nil {
+			m.err = fmt.Sprintf("save task: %v", err)
+			return m, nil
+		}
+	} else {
+		// create new
+		t := task.New(title)
+		t.Priority = m.priority
+		t.DueDate = dueDate
+		t.Tags = tags
+		if err := m.vault.Tasks().Add(t); err != nil {
+			m.err = fmt.Sprintf("add task: %v", err)
+			return m, nil
+		}
+	}
+
+	return m, func() tea.Msg { return navigateMsg{view: viewTaskList} }
+}
+
+var (
+	formLabelStyle    = lipgloss.NewStyle().Foreground(zstyle.Subtext1)
+	formActiveLabel   = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent).Bold(true)
+	formPriorityStyle = lipgloss.NewStyle().Foreground(zstyle.Text)
+)
+
+func (m taskFormModel) View() string {
+	var b strings.Builder
+	b.WriteString("\n")
+
+	// mode label
+	mode := "New Task"
+	if m.editing != nil {
+		mode = "Edit Task"
+	}
+	modeStyle := lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent).Bold(true)
+	b.WriteString(fmt.Sprintf("  %s\n\n", modeStyle.Render(mode)))
+
+	// title field
+	label := formLabelStyle
+	if m.focused == fieldTitle {
+		label = formActiveLabel
+	}
+	b.WriteString(fmt.Sprintf("  %s\n", label.Render("Title")))
+	b.WriteString(fmt.Sprintf("  %s\n\n", m.title.View()))
+
+	// priority field
+	label = formLabelStyle
+	if m.focused == fieldPriority {
+		label = formActiveLabel
+	}
+	b.WriteString(fmt.Sprintf("  %s\n", label.Render("Priority")))
+	b.WriteString(fmt.Sprintf("  %s\n\n", m.renderPrioritySelector()))
+
+	// due date field
+	label = formLabelStyle
+	if m.focused == fieldDue {
+		label = formActiveLabel
+	}
+	b.WriteString(fmt.Sprintf("  %s\n", label.Render("Due Date")))
+	b.WriteString(fmt.Sprintf("  %s\n\n", m.due.View()))
+
+	// tags field
+	label = formLabelStyle
+	if m.focused == fieldTags {
+		label = formActiveLabel
+	}
+	b.WriteString(fmt.Sprintf("  %s\n", label.Render("Tags")))
+	b.WriteString(fmt.Sprintf("  %s\n", m.tags.View()))
+
+	// error
+	if m.err != "" {
+		b.WriteString(fmt.Sprintf("\n  %s\n", zstyle.StatusErr.Render(m.err)))
+	}
+
+	return b.String()
+}
+
+func (m taskFormModel) renderPrioritySelector() string {
+	display := formatPriority(m.priority)
+	style := formPriorityStyle
+
+	switch m.priority {
+	case task.PriorityHigh:
+		style = lipgloss.NewStyle().Foreground(zstyle.Red).Bold(true)
+	case task.PriorityMedium:
+		style = lipgloss.NewStyle().Foreground(zstyle.Yellow)
+	case task.PriorityLow:
+		style = lipgloss.NewStyle().Foreground(zstyle.Text)
+	}
+
+	if m.focused == fieldPriority {
+		return fmt.Sprintf("▸ %s %s", style.Render(display),
+			zstyle.MutedText.Render("(enter/space to cycle)"))
+	}
+	return fmt.Sprintf("  %s", style.Render(display))
+}

--- a/internal/tui/task_form_test.go
+++ b/internal/tui/task_form_test.go
@@ -1,0 +1,428 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zarlcorp/zvault/internal/task"
+)
+
+func TestTaskFormCreateMode(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	view := m.View()
+	if !strings.Contains(view, "New Task") {
+		t.Error("create mode should show 'New Task'")
+	}
+	if m.editing != nil {
+		t.Error("create mode should have nil editing")
+	}
+}
+
+func TestTaskFormEditMode(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Edit this", withPriority(task.PriorityHigh), withTags("work"))
+
+	m := newTaskFormModel(v)
+	m.loadTask(tk)
+
+	view := m.View()
+	if !strings.Contains(view, "Edit Task") {
+		t.Error("edit mode should show 'Edit Task'")
+	}
+	if m.editing == nil {
+		t.Error("edit mode should have non-nil editing")
+	}
+	if m.title.Value() != "Edit this" {
+		t.Errorf("title input = %q, want 'Edit this'", m.title.Value())
+	}
+	if m.priority != task.PriorityHigh {
+		t.Errorf("priority = %q, want high", m.priority)
+	}
+}
+
+func TestTaskFormNavigateMsg(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Nav edit")
+
+	m := newTaskFormModel(v)
+
+	// navigate with task data (edit mode)
+	m, _ = m.Update(navigateMsg{view: viewTaskForm, data: tk})
+	if m.editing == nil {
+		t.Error("should be in edit mode")
+	}
+
+	// navigate with nil data (create mode)
+	m, _ = m.Update(navigateMsg{view: viewTaskForm, data: nil})
+	if m.editing != nil {
+		t.Error("should be in create mode")
+	}
+}
+
+func TestTaskFormEscCancels(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc should produce navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskList {
+		t.Fatalf("nav = %d, want viewTaskList", nav.view)
+	}
+}
+
+func TestTaskFormTabNavigation(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	if m.focused != fieldTitle {
+		t.Fatalf("initial focus = %d, want fieldTitle", m.focused)
+	}
+
+	// tab to priority
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.focused != fieldPriority {
+		t.Fatalf("after tab: focus = %d, want fieldPriority", m.focused)
+	}
+
+	// tab to due
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.focused != fieldDue {
+		t.Fatalf("after 2 tabs: focus = %d, want fieldDue", m.focused)
+	}
+
+	// tab to tags
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.focused != fieldTags {
+		t.Fatalf("after 3 tabs: focus = %d, want fieldTags", m.focused)
+	}
+
+	// tab wraps to title
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.focused != fieldTitle {
+		t.Fatalf("after 4 tabs: focus = %d, want fieldTitle (wrap)", m.focused)
+	}
+}
+
+func TestTaskFormShiftTabNavigation(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	// shift-tab from title should wrap to tags
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if m.focused != fieldTags {
+		t.Fatalf("shift-tab from title: focus = %d, want fieldTags", m.focused)
+	}
+}
+
+func TestTaskFormPriorityCycling(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	if m.priority != task.PriorityNone {
+		t.Fatalf("initial priority = %q, want none", m.priority)
+	}
+
+	// move to priority field
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	// cycle through priorities with enter
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.priority != task.PriorityLow {
+		t.Fatalf("after 1 cycle: priority = %q, want low", m.priority)
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.priority != task.PriorityMedium {
+		t.Fatalf("after 2 cycles: priority = %q, want medium", m.priority)
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.priority != task.PriorityHigh {
+		t.Fatalf("after 3 cycles: priority = %q, want high", m.priority)
+	}
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.priority != task.PriorityNone {
+		t.Fatalf("after 4 cycles: priority = %q, want none (wrap)", m.priority)
+	}
+}
+
+func TestTaskFormPriorityCycleWithSpace(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	// move to priority field
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	// cycle with space
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if m.priority != task.PriorityLow {
+		t.Fatalf("after space: priority = %q, want low", m.priority)
+	}
+}
+
+func TestTaskFormSaveNewTask(t *testing.T) {
+	orig := nowFunc
+	defer func() { nowFunc = orig }()
+	nowFunc = fixedTime(2026, time.February, 18)
+
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	// type title
+	m.title.SetValue("New task")
+
+	// set priority
+	m.priority = task.PriorityMedium
+
+	// set due date
+	m.due.SetValue("tomorrow")
+
+	// set tags
+	m.tags.SetValue("work, urgent")
+
+	// save with ctrl+s
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("ctrl+s should produce navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskList {
+		t.Fatalf("nav = %d, want viewTaskList", nav.view)
+	}
+
+	// verify task was created
+	tasks, err := v.Tasks().List(task.Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].Title != "New task" {
+		t.Errorf("title = %q, want 'New task'", tasks[0].Title)
+	}
+	if tasks[0].Priority != task.PriorityMedium {
+		t.Errorf("priority = %q, want medium", tasks[0].Priority)
+	}
+	if tasks[0].DueDate == nil {
+		t.Error("due date should be set")
+	} else {
+		expected := time.Date(2026, 2, 19, 0, 0, 0, 0, time.Local)
+		if !tasks[0].DueDate.Equal(expected) {
+			t.Errorf("due = %v, want %v", tasks[0].DueDate, expected)
+		}
+	}
+	if len(tasks[0].Tags) != 2 || tasks[0].Tags[0] != "work" || tasks[0].Tags[1] != "urgent" {
+		t.Errorf("tags = %v, want [work urgent]", tasks[0].Tags)
+	}
+}
+
+func TestTaskFormSaveEnterOnLast(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	m.title.SetValue("Enter save")
+
+	// navigate to tags (last field)
+	m.focused = fieldTags
+	m.title.Blur()
+	m.tags.Focus()
+
+	// enter on last field should save
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on last field should save")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskList {
+		t.Fatalf("nav = %d, want viewTaskList", nav.view)
+	}
+}
+
+func TestTaskFormSaveRequiresTitle(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	// leave title empty, try to save
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if m.err != "title is required" {
+		t.Fatalf("err = %q, want 'title is required'", m.err)
+	}
+}
+
+func TestTaskFormSaveInvalidDate(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	m.title.SetValue("Test")
+	m.due.SetValue("invalid-date")
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if m.err == "" {
+		t.Fatal("should show error for invalid date")
+	}
+}
+
+func TestTaskFormUpdateExisting(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Original", withPriority(task.PriorityLow))
+
+	m := newTaskFormModel(v)
+	m.loadTask(tk)
+
+	m.title.SetValue("Updated")
+	m.priority = task.PriorityHigh
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("should navigate after save")
+	}
+
+	// verify update
+	got, err := v.Tasks().Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "Updated" {
+		t.Errorf("title = %q, want 'Updated'", got.Title)
+	}
+	if got.Priority != task.PriorityHigh {
+		t.Errorf("priority = %q, want high", got.Priority)
+	}
+}
+
+func TestTaskFormEnterOnTitle(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	// enter on title should move to next field, not save
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.focused != fieldPriority {
+		t.Fatalf("focus = %d, want fieldPriority (enter on title moves forward)", m.focused)
+	}
+}
+
+func TestTaskFormNoVault(t *testing.T) {
+	m := newTaskFormModel(nil)
+	m.reset()
+	m.title.SetValue("Test")
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if m.err != "vault not available" {
+		t.Fatalf("err = %q, want 'vault not available'", m.err)
+	}
+}
+
+func TestTaskFormLoadWithDueDate(t *testing.T) {
+	v := openTestVault(t)
+	due := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	tk := addTask(t, v, "With due", withDue(due))
+
+	m := newTaskFormModel(v)
+	m.loadTask(tk)
+
+	if m.due.Value() != "2026-03-15" {
+		t.Errorf("due input = %q, want '2026-03-15'", m.due.Value())
+	}
+}
+
+func TestTaskFormEmptyDueDate(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	m.title.SetValue("No due date")
+	// leave due empty
+
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("should save successfully")
+	}
+
+	tasks, _ := v.Tasks().List(task.Filter{})
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].DueDate != nil {
+		t.Error("due date should be nil")
+	}
+}
+
+func TestTaskFormEmptyTags(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	m.title.SetValue("No tags")
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+
+	tasks, _ := v.Tasks().List(task.Filter{})
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if len(tasks[0].Tags) != 0 {
+		t.Errorf("tags = %v, want empty", tasks[0].Tags)
+	}
+}
+
+func TestTaskFormViewShowsPrioritySelector(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	view := m.View()
+	if !strings.Contains(view, "Priority") {
+		t.Error("should show Priority label")
+	}
+	if !strings.Contains(view, "None") {
+		t.Error("should show initial priority value")
+	}
+}
+
+func TestTaskFormClearError(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskFormModel(v)
+	m.reset()
+
+	// trigger error
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if m.err == "" {
+		t.Fatal("should have error")
+	}
+
+	// any key should clear error
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if m.err != "" {
+		t.Fatalf("error should be cleared, got %q", m.err)
+	}
+}

--- a/internal/tui/task_list.go
+++ b/internal/tui/task_list.go
@@ -1,0 +1,450 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/zarlcorp/core/pkg/zstyle"
+	"github.com/zarlcorp/zvault/internal/task"
+	"github.com/zarlcorp/zvault/internal/vault"
+)
+
+// filterMode cycles between task list filter modes.
+type filterMode int
+
+const (
+	filterAll filterMode = iota
+	filterPendingOnly
+	filterDoneOnly
+	filterModeCount // sentinel
+)
+
+// taskListModel is the task list view.
+type taskListModel struct {
+	vault    *vault.Vault
+	tasks    []task.Task
+	cursor   int
+	filter   filterMode
+	tags     []string    // unique tags across all tasks for tag filtering
+	tagIndex int         // which tag is selected when cycling tags
+	width    int
+	height   int
+	confirm  confirmKind // active confirmation prompt
+	doneCount int        // cached count of done tasks for clear prompt
+}
+
+// confirmKind tracks which confirmation prompt is active.
+type confirmKind int
+
+const (
+	confirmNone confirmKind = iota
+	confirmDelete
+	confirmClearDone
+)
+
+func newTaskListModel(v *vault.Vault) taskListModel {
+	m := taskListModel{vault: v}
+	m.loadTasks()
+	return m
+}
+
+func (m *taskListModel) loadTasks() {
+	if m.vault == nil {
+		m.tasks = nil
+		return
+	}
+
+	f := m.taskFilter()
+	tasks, err := m.vault.Tasks().List(f)
+	if err != nil {
+		m.tasks = nil
+		return
+	}
+
+	sortTasks(tasks)
+	m.tasks = tasks
+
+	// count done tasks for clear prompt
+	all, err := m.vault.Tasks().List(task.Filter{})
+	if err == nil {
+		count := 0
+		for _, t := range all {
+			if t.Done {
+				count++
+			}
+		}
+		m.doneCount = count
+	}
+
+	// collect unique tags
+	m.collectTags()
+
+	// clamp cursor
+	if m.cursor >= len(m.tasks) {
+		m.cursor = max(0, len(m.tasks)-1)
+	}
+}
+
+func (m *taskListModel) collectTags() {
+	seen := make(map[string]bool)
+	if m.vault == nil {
+		m.tags = nil
+		return
+	}
+	all, err := m.vault.Tasks().List(task.Filter{})
+	if err != nil {
+		return
+	}
+	for _, t := range all {
+		for _, tag := range t.Tags {
+			if !seen[tag] {
+				seen[tag] = true
+				m.tags = append(m.tags, tag)
+			}
+		}
+	}
+	sort.Strings(m.tags)
+}
+
+func (m taskListModel) taskFilter() task.Filter {
+	switch m.filter {
+	case filterPendingOnly:
+		return task.Filter{Status: task.FilterPending}
+	case filterDoneOnly:
+		return task.Filter{Status: task.FilterDone}
+	default:
+		return task.Filter{}
+	}
+}
+
+// sortTasks sorts: pending first, then by priority (high > medium > low > none), then by due date (soonest first, nil last).
+func sortTasks(tasks []task.Task) {
+	sort.SliceStable(tasks, func(i, j int) bool {
+		a, b := tasks[i], tasks[j]
+
+		// pending before done
+		if a.Done != b.Done {
+			return !a.Done
+		}
+
+		// higher priority first
+		pa, pb := priorityRank(a.Priority), priorityRank(b.Priority)
+		if pa != pb {
+			return pa > pb
+		}
+
+		// soonest due date first, nil last
+		if a.DueDate != nil && b.DueDate != nil {
+			if !a.DueDate.Equal(*b.DueDate) {
+				return a.DueDate.Before(*b.DueDate)
+			}
+		}
+		if a.DueDate != nil && b.DueDate == nil {
+			return true
+		}
+		if a.DueDate == nil && b.DueDate != nil {
+			return false
+		}
+
+		return false
+	})
+}
+
+func priorityRank(p task.Priority) int {
+	switch p {
+	case task.PriorityHigh:
+		return 3
+	case task.PriorityMedium:
+		return 2
+	case task.PriorityLow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// tasksRefreshedMsg signals the list should reload.
+type tasksRefreshedMsg struct{}
+
+func (m taskListModel) Update(msg tea.Msg) (taskListModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tasksRefreshedMsg:
+		m.loadTasks()
+		return m, nil
+
+	case navigateMsg:
+		if msg.view == viewTaskList {
+			m.loadTasks()
+			m.confirm = confirmNone
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		// handle confirmation prompts first
+		if m.confirm != confirmNone {
+			return m.handleConfirm(msg)
+		}
+
+		switch {
+		case key.Matches(msg, zstyle.KeyBack):
+			return m, func() tea.Msg { return navigateMsg{view: viewMenu} }
+
+		case key.Matches(msg, zstyle.KeyUp):
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case key.Matches(msg, zstyle.KeyDown):
+			if m.cursor < len(m.tasks)-1 {
+				m.cursor++
+			}
+
+		case key.Matches(msg, zstyle.KeyEnter):
+			if len(m.tasks) > 0 {
+				t := m.tasks[m.cursor]
+				return m, func() tea.Msg { return navigateMsg{view: viewTaskDetail, data: t.ID} }
+			}
+
+		case msg.String() == " ":
+			// toggle done
+			if len(m.tasks) > 0 {
+				return m.toggleDone()
+			}
+
+		case msg.String() == "n":
+			return m, func() tea.Msg { return navigateMsg{view: viewTaskForm, data: nil} }
+
+		case msg.String() == "d":
+			if len(m.tasks) > 0 {
+				m.confirm = confirmDelete
+			}
+
+		case msg.String() == "x":
+			if m.doneCount > 0 {
+				m.confirm = confirmClearDone
+			}
+
+		case key.Matches(msg, zstyle.KeyTab):
+			m.filter = (m.filter + 1) % filterModeCount
+			m.loadTasks()
+		}
+	}
+	return m, nil
+}
+
+func (m taskListModel) handleConfirm(msg tea.KeyMsg) (taskListModel, tea.Cmd) {
+	switch msg.String() {
+	case "y":
+		switch m.confirm {
+		case confirmDelete:
+			m.confirm = confirmNone
+			return m.deleteSelected()
+		case confirmClearDone:
+			m.confirm = confirmNone
+			return m.clearDone()
+		}
+	case "n", "esc":
+		m.confirm = confirmNone
+	}
+	return m, nil
+}
+
+func (m taskListModel) toggleDone() (taskListModel, tea.Cmd) {
+	if m.vault == nil || len(m.tasks) == 0 {
+		return m, nil
+	}
+
+	t := m.tasks[m.cursor]
+	t.Done = !t.Done
+	if t.Done {
+		now := nowFunc()
+		t.CompletedAt = &now
+	} else {
+		t.CompletedAt = nil
+	}
+
+	if err := m.vault.Tasks().Update(t); err != nil {
+		return m, func() tea.Msg { return errMsg{err: err} }
+	}
+
+	m.loadTasks()
+	return m, nil
+}
+
+func (m taskListModel) deleteSelected() (taskListModel, tea.Cmd) {
+	if m.vault == nil || len(m.tasks) == 0 {
+		return m, nil
+	}
+
+	t := m.tasks[m.cursor]
+	if err := m.vault.Tasks().Delete(t.ID); err != nil {
+		return m, func() tea.Msg { return errMsg{err: err} }
+	}
+
+	m.loadTasks()
+	return m, nil
+}
+
+func (m taskListModel) clearDone() (taskListModel, tea.Cmd) {
+	if m.vault == nil {
+		return m, nil
+	}
+
+	_, err := m.vault.Tasks().ClearDone()
+	if err != nil {
+		return m, func() tea.Msg { return errMsg{err: err} }
+	}
+
+	m.loadTasks()
+	return m, nil
+}
+
+var (
+	taskHighStyle   = lipgloss.NewStyle().Foreground(zstyle.Red).Bold(true)
+	taskMediumStyle = lipgloss.NewStyle().Foreground(zstyle.Yellow)
+	taskDoneStyle   = lipgloss.NewStyle().Foreground(zstyle.Overlay0).Strikethrough(true)
+	taskDueDimStyle = lipgloss.NewStyle().Foreground(zstyle.Overlay1)
+	taskDueRedStyle = lipgloss.NewStyle().Foreground(zstyle.Red)
+	taskTagStyle    = lipgloss.NewStyle().Foreground(zstyle.Sapphire)
+	taskCursorStyle = lipgloss.NewStyle().Foreground(zstyle.ZvaultAccent)
+)
+
+func (m taskListModel) View() string {
+	var b strings.Builder
+	b.WriteString("\n")
+
+	// filter indicator
+	filterLabel := m.filterLabel()
+	b.WriteString(fmt.Sprintf("  %s\n\n", zstyle.MutedText.Render(filterLabel)))
+
+	if len(m.tasks) == 0 {
+		b.WriteString(fmt.Sprintf("  %s\n", zstyle.MutedText.Render("no tasks")))
+		return b.String()
+	}
+
+	// visible tasks (constrain to available height)
+	maxVisible := m.height - 10 // header, footer, filter, padding
+	if maxVisible < 3 {
+		maxVisible = 3
+	}
+
+	// calculate scroll window
+	start := 0
+	if m.cursor >= maxVisible {
+		start = m.cursor - maxVisible + 1
+	}
+	end := start + maxVisible
+	if end > len(m.tasks) {
+		end = len(m.tasks)
+		start = max(0, end-maxVisible)
+	}
+
+	for i := start; i < end; i++ {
+		t := m.tasks[i]
+		line := m.renderTaskLine(t, i == m.cursor)
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	// show scroll indicator
+	if len(m.tasks) > maxVisible {
+		b.WriteString(fmt.Sprintf("\n  %s\n", zstyle.MutedText.Render(
+			fmt.Sprintf("(%d of %d)", m.cursor+1, len(m.tasks)),
+		)))
+	}
+
+	// confirmation prompt
+	if m.confirm != confirmNone {
+		b.WriteString("\n")
+		b.WriteString(m.confirmPrompt())
+	}
+
+	return b.String()
+}
+
+func (m taskListModel) filterLabel() string {
+	switch m.filter {
+	case filterPendingOnly:
+		return "Filter: Pending"
+	case filterDoneOnly:
+		return "Filter: Done"
+	default:
+		return "Filter: All"
+	}
+}
+
+func (m taskListModel) renderTaskLine(t task.Task, selected bool) string {
+	var parts []string
+
+	// cursor
+	cursor := "  "
+	if selected {
+		cursor = taskCursorStyle.Render("▸ ")
+	}
+
+	// checkbox
+	check := "[ ]"
+	if t.Done {
+		check = "[x]"
+	}
+
+	// priority indicator
+	pri := "  "
+	switch t.Priority {
+	case task.PriorityHigh:
+		pri = taskHighStyle.Render("!!")
+	case task.PriorityMedium:
+		pri = taskMediumStyle.Render(" !")
+	}
+
+	// title
+	title := t.Title
+	if t.Done {
+		title = taskDoneStyle.Render(title)
+	}
+
+	parts = append(parts, cursor+check, pri, title)
+
+	// due date
+	if t.DueDate != nil {
+		dueStr := formatDueDate(t.DueDate)
+		if t.Done {
+			dueStr = taskDueDimStyle.Render("due: " + dueStr)
+		} else if isOverdue(t.DueDate) {
+			dueStr = taskDueRedStyle.Render("due: " + dueStr)
+		} else {
+			dueStr = taskDueDimStyle.Render("due: " + dueStr)
+		}
+		parts = append(parts, " "+dueStr)
+	}
+
+	// tags
+	if len(t.Tags) > 0 {
+		var tagStrs []string
+		for _, tag := range t.Tags {
+			tagStrs = append(tagStrs, "#"+tag)
+		}
+		parts = append(parts, " "+taskTagStyle.Render(strings.Join(tagStrs, " ")))
+	}
+
+	return "  " + strings.Join(parts, " ")
+}
+
+func (m taskListModel) confirmPrompt() string {
+	switch m.confirm {
+	case confirmDelete:
+		if len(m.tasks) > 0 {
+			t := m.tasks[m.cursor]
+			return fmt.Sprintf("  %s",
+				zstyle.StatusWarn.Render(fmt.Sprintf("Delete \"%s\"? (y/n)", t.Title)))
+		}
+	case confirmClearDone:
+		return fmt.Sprintf("  %s",
+			zstyle.StatusWarn.Render(fmt.Sprintf("Clear %d done tasks? (y/n)", m.doneCount)))
+	}
+	return ""
+}

--- a/internal/tui/task_list_test.go
+++ b/internal/tui/task_list_test.go
@@ -1,0 +1,501 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zarlcorp/core/pkg/zfilesystem"
+	"github.com/zarlcorp/zvault/internal/task"
+	"github.com/zarlcorp/zvault/internal/vault"
+)
+
+func openTestVault(t *testing.T) *vault.Vault {
+	t.Helper()
+	v, err := vault.OpenFS(zfilesystem.NewMemFS(), "test-password")
+	if err != nil {
+		t.Fatalf("open vault: %v", err)
+	}
+	t.Cleanup(func() { v.Close() })
+	return v
+}
+
+func addTask(t *testing.T, v *vault.Vault, title string, opts ...func(*task.Task)) task.Task {
+	t.Helper()
+	tk := task.New(title)
+	for _, opt := range opts {
+		opt(&tk)
+	}
+	if err := v.Tasks().Add(tk); err != nil {
+		t.Fatalf("add task: %v", err)
+	}
+	return tk
+}
+
+func withPriority(p task.Priority) func(*task.Task) {
+	return func(t *task.Task) { t.Priority = p }
+}
+
+func withDue(d time.Time) func(*task.Task) {
+	return func(t *task.Task) { t.DueDate = &d }
+}
+
+func withDone() func(*task.Task) {
+	return func(t *task.Task) {
+		t.Done = true
+		now := time.Now()
+		t.CompletedAt = &now
+	}
+}
+
+func withTags(tags ...string) func(*task.Task) {
+	return func(t *task.Task) { t.Tags = tags }
+}
+
+func TestTaskListEmpty(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskListModel(v)
+	view := m.View()
+	if !strings.Contains(view, "no tasks") {
+		t.Error("empty task list should show 'no tasks'")
+	}
+}
+
+func TestTaskListShowsTasks(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Buy groceries")
+	addTask(t, v, "Fix bug")
+
+	m := newTaskListModel(v)
+	view := m.View()
+	if !strings.Contains(view, "Buy groceries") {
+		t.Error("view should show first task")
+	}
+	if !strings.Contains(view, "Fix bug") {
+		t.Error("view should show second task")
+	}
+}
+
+func TestTaskListPriorityIndicators(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "High task", withPriority(task.PriorityHigh))
+	addTask(t, v, "Medium task", withPriority(task.PriorityMedium))
+	addTask(t, v, "Low task", withPriority(task.PriorityLow))
+
+	m := newTaskListModel(v)
+	view := m.View()
+	// priority indicators should be present (with ANSI codes)
+	if !strings.Contains(view, "High task") {
+		t.Error("should show high priority task")
+	}
+	if !strings.Contains(view, "Medium task") {
+		t.Error("should show medium priority task")
+	}
+}
+
+func TestTaskListCheckbox(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Pending task")
+	addTask(t, v, "Done task", withDone())
+
+	m := newTaskListModel(v)
+	view := m.View()
+	if !strings.Contains(view, "[ ]") {
+		t.Error("pending task should show unchecked checkbox")
+	}
+	if !strings.Contains(view, "[x]") {
+		t.Error("done task should show checked checkbox")
+	}
+}
+
+func TestTaskListDueDate(t *testing.T) {
+	orig := nowFunc
+	defer func() { nowFunc = orig }()
+	nowFunc = fixedTime(2026, time.February, 18)
+
+	v := openTestVault(t)
+	tomorrow := time.Date(2026, 2, 19, 0, 0, 0, 0, time.Local)
+	addTask(t, v, "Tomorrow task", withDue(tomorrow))
+
+	m := newTaskListModel(v)
+	view := m.View()
+	if !strings.Contains(view, "tomorrow") {
+		t.Error("should show relative due date")
+	}
+}
+
+func TestTaskListTags(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Tagged task", withTags("urgent", "work"))
+
+	m := newTaskListModel(v)
+	view := m.View()
+	if !strings.Contains(view, "#urgent") {
+		t.Error("should show tag")
+	}
+	if !strings.Contains(view, "#work") {
+		t.Error("should show second tag")
+	}
+}
+
+func TestTaskListSortOrder(t *testing.T) {
+	v := openTestVault(t)
+
+	addTask(t, v, "Done task", withDone())
+	addTask(t, v, "Low priority", withPriority(task.PriorityLow))
+	addTask(t, v, "High priority", withPriority(task.PriorityHigh))
+	addTask(t, v, "Medium priority", withPriority(task.PriorityMedium))
+
+	m := newTaskListModel(v)
+
+	// pending tasks should come first, sorted by priority
+	if len(m.tasks) != 4 {
+		t.Fatalf("expected 4 tasks, got %d", len(m.tasks))
+	}
+
+	// first three should be pending, ordered by priority
+	if m.tasks[0].Title != "High priority" {
+		t.Errorf("first task = %q, want 'High priority'", m.tasks[0].Title)
+	}
+	if m.tasks[1].Title != "Medium priority" {
+		t.Errorf("second task = %q, want 'Medium priority'", m.tasks[1].Title)
+	}
+	if m.tasks[2].Title != "Low priority" {
+		t.Errorf("third task = %q, want 'Low priority'", m.tasks[2].Title)
+	}
+	// done task should be last
+	if m.tasks[3].Title != "Done task" {
+		t.Errorf("last task = %q, want 'Done task'", m.tasks[3].Title)
+	}
+}
+
+func TestTaskListSortByDueDate(t *testing.T) {
+	v := openTestVault(t)
+
+	later := time.Date(2026, 3, 15, 0, 0, 0, 0, time.Local)
+	sooner := time.Date(2026, 2, 20, 0, 0, 0, 0, time.Local)
+	addTask(t, v, "Later", withDue(later))
+	addTask(t, v, "Sooner", withDue(sooner))
+	addTask(t, v, "No date")
+
+	m := newTaskListModel(v)
+
+	if m.tasks[0].Title != "Sooner" {
+		t.Errorf("first = %q, want 'Sooner'", m.tasks[0].Title)
+	}
+	if m.tasks[1].Title != "Later" {
+		t.Errorf("second = %q, want 'Later'", m.tasks[1].Title)
+	}
+	if m.tasks[2].Title != "No date" {
+		t.Errorf("third = %q, want 'No date'", m.tasks[2].Title)
+	}
+}
+
+func TestTaskListNavigateUpDown(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Task 1")
+	addTask(t, v, "Task 2")
+	addTask(t, v, "Task 3")
+
+	m := newTaskListModel(v)
+	if m.cursor != 0 {
+		t.Fatalf("initial cursor = %d, want 0", m.cursor)
+	}
+
+	// move down
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 1 {
+		t.Fatalf("cursor after down = %d, want 1", m.cursor)
+	}
+
+	// move down again
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 2 {
+		t.Fatalf("cursor after 2 down = %d, want 2", m.cursor)
+	}
+
+	// can't go past end
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 2 {
+		t.Fatalf("cursor should stay at 2, got %d", m.cursor)
+	}
+
+	// move up
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if m.cursor != 1 {
+		t.Fatalf("cursor after up = %d, want 1", m.cursor)
+	}
+}
+
+func TestTaskListEscGoesBack(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskListModel(v)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc should produce navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewMenu {
+		t.Fatalf("nav = %d, want viewMenu", nav.view)
+	}
+}
+
+func TestTaskListEnterOpensDetail(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Detail task")
+
+	m := newTaskListModel(v)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter should produce navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskDetail {
+		t.Fatalf("nav = %d, want viewTaskDetail", nav.view)
+	}
+	if nav.data != tk.ID {
+		t.Fatalf("nav data = %v, want %q", nav.data, tk.ID)
+	}
+}
+
+func TestTaskListNewTask(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskListModel(v)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd == nil {
+		t.Fatal("n should produce navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(navigateMsg)
+	if !ok {
+		t.Fatalf("expected navigateMsg, got %T", msg)
+	}
+	if nav.view != viewTaskForm {
+		t.Fatalf("nav = %d, want viewTaskForm", nav.view)
+	}
+	if nav.data != nil {
+		t.Fatalf("nav data = %v, want nil (create mode)", nav.data)
+	}
+}
+
+func TestTaskListToggleDone(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Toggle me")
+
+	m := newTaskListModel(v)
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	// verify task is now done
+	got, err := v.Tasks().Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.Done {
+		t.Error("task should be done after toggle")
+	}
+	if got.CompletedAt == nil {
+		t.Error("task should have CompletedAt set")
+	}
+
+	// toggle back
+	// after reload, the done task may have moved - find it
+	for i, tt := range m.tasks {
+		if tt.ID == tk.ID {
+			m.cursor = i
+			break
+		}
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	got, err = v.Tasks().Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Done {
+		t.Error("task should be pending after second toggle")
+	}
+}
+
+func TestTaskListDeleteConfirmation(t *testing.T) {
+	v := openTestVault(t)
+	tk := addTask(t, v, "Delete me")
+
+	m := newTaskListModel(v)
+
+	// press d - should show confirmation
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if m.confirm != confirmDelete {
+		t.Fatal("should be in delete confirmation")
+	}
+	view := m.View()
+	if !strings.Contains(view, "Delete") {
+		t.Error("should show delete prompt")
+	}
+
+	// press n to cancel
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.confirm != confirmNone {
+		t.Fatal("should cancel confirmation")
+	}
+
+	// task should still exist
+	_, err := v.Tasks().Get(tk.ID)
+	if err != nil {
+		t.Fatal("task should still exist after cancel")
+	}
+
+	// press d again, then y to confirm
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	_, err = v.Tasks().Get(tk.ID)
+	if err == nil {
+		t.Fatal("task should be deleted after confirm")
+	}
+}
+
+func TestTaskListClearDone(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Pending task")
+	addTask(t, v, "Done 1", withDone())
+	addTask(t, v, "Done 2", withDone())
+
+	m := newTaskListModel(v)
+
+	// press x - should show confirmation
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if m.confirm != confirmClearDone {
+		t.Fatal("should be in clear-done confirmation")
+	}
+	view := m.View()
+	if !strings.Contains(view, "Clear 2 done") {
+		t.Errorf("should show count in clear prompt, got: %s", view)
+	}
+
+	// confirm
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	// only pending task should remain
+	all, err := v.Tasks().List(task.Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("remaining = %d, want 1", len(all))
+	}
+	if all[0].Title != "Pending task" {
+		t.Errorf("remaining title = %q, want 'Pending task'", all[0].Title)
+	}
+}
+
+func TestTaskListClearDoneNoOp(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Pending task")
+
+	m := newTaskListModel(v)
+
+	// press x with no done tasks - should not trigger confirmation
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if m.confirm != confirmNone {
+		t.Fatal("should not enter confirmation when no done tasks")
+	}
+}
+
+func TestTaskListFilterCycling(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Pending")
+	addTask(t, v, "Done", withDone())
+
+	m := newTaskListModel(v)
+
+	// initial: all
+	if m.filter != filterAll {
+		t.Fatalf("initial filter = %d, want filterAll", m.filter)
+	}
+	if len(m.tasks) != 2 {
+		t.Fatalf("all: len = %d, want 2", len(m.tasks))
+	}
+
+	// tab -> pending
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.filter != filterPendingOnly {
+		t.Fatalf("after tab: filter = %d, want filterPendingOnly", m.filter)
+	}
+	if len(m.tasks) != 1 {
+		t.Fatalf("pending: len = %d, want 1", len(m.tasks))
+	}
+
+	// tab -> done
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.filter != filterDoneOnly {
+		t.Fatalf("after 2 tabs: filter = %d, want filterDoneOnly", m.filter)
+	}
+	if len(m.tasks) != 1 {
+		t.Fatalf("done: len = %d, want 1", len(m.tasks))
+	}
+
+	// tab -> wraps back to all
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if m.filter != filterAll {
+		t.Fatalf("after 3 tabs: filter = %d, want filterAll", m.filter)
+	}
+}
+
+func TestTaskListFilterLabel(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskListModel(v)
+
+	tests := []struct {
+		filter filterMode
+		want   string
+	}{
+		{filterAll, "Filter: All"},
+		{filterPendingOnly, "Filter: Pending"},
+		{filterDoneOnly, "Filter: Done"},
+	}
+
+	for _, tt := range tests {
+		m.filter = tt.filter
+		view := m.View()
+		if !strings.Contains(view, tt.want) {
+			t.Errorf("filter %d: view should contain %q", tt.filter, tt.want)
+		}
+	}
+}
+
+func TestTaskListEnterOnEmptyList(t *testing.T) {
+	v := openTestVault(t)
+	m := newTaskListModel(v)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("enter on empty list should not produce command")
+	}
+}
+
+func TestTaskListCursorClamps(t *testing.T) {
+	v := openTestVault(t)
+	addTask(t, v, "Task 1")
+	addTask(t, v, "Task 2")
+	addTask(t, v, "Task 3")
+
+	m := newTaskListModel(v)
+	m.cursor = 2
+
+	// delete last task
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	// cursor should clamp to new last index
+	if m.cursor >= len(m.tasks) {
+		t.Fatalf("cursor = %d, but only %d tasks remain", m.cursor, len(m.tasks))
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -68,14 +68,31 @@ func TestCtrlCQuitsFromMenu(t *testing.T) {
 	}
 }
 
-func TestQQuitsFromPlaceholder(t *testing.T) {
-	views := []viewID{viewSecretList, viewSecretDetail, viewSecretForm, viewTaskList, viewTaskDetail, viewTaskForm}
+func TestQQuitsFromNonInputViews(t *testing.T) {
+	// views without text inputs: q quits
+	views := []viewID{viewSecretList, viewSecretDetail, viewTaskList, viewTaskDetail}
 	for _, v := range views {
 		m := newTestModel()
 		m.view = v
 		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 		if cmd == nil {
 			t.Fatalf("q should return quit command from view %d", v)
+		}
+	}
+}
+
+func TestQDoesNotQuitFromFormViews(t *testing.T) {
+	// views with text inputs: q types, does not quit
+	views := []viewID{viewSecretForm, viewTaskForm}
+	for _, v := range views {
+		m := newTestModel()
+		m.view = v
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+		if cmd != nil {
+			msg := cmd()
+			if _, ok := msg.(tea.QuitMsg); ok {
+				t.Fatalf("q should not quit from form view %d (text input)", v)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #18

Spec: .manager/specs/049-zvault-tui-tasks.md

## Changes
- Task list view: scrollable with checkbox, priority indicators (!! high, ! medium), title, relative due dates, tags
- Done tasks dimmed with strikethrough, overdue dates in red
- Sort: pending first, then priority (high→low), then due date (soonest first)
- Filter cycling (all/pending/done) via tab
- Space toggles done immediately, `x` clears all done (with confirmation)
- Task detail view: full info with relative date display, edit/toggle/delete
- Task form: create/edit with title, priority cycling, date input (YYYY-MM-DD, tomorrow, +3d, next week), tags
- Date parsing/display utilities in dates.go with 15 test cases
- 81 TUI tests passing (63 new + 18 existing)